### PR TITLE
fix: pin scorecard sarif source root

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -76,3 +76,4 @@ jobs:
         uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
         with:
           sarif_file: results.sarif
+          checkout_path: ${{ github.workspace }}

--- a/tests/automationMetadata.test.ts
+++ b/tests/automationMetadata.test.ts
@@ -26,6 +26,10 @@ const dependabotAutoMergeWorkflow = readFileSync(
   join(repoRoot, ".github", "workflows", "dependabot-auto-merge.yml"),
   "utf8"
 );
+const scorecardWorkflow = readFileSync(
+  join(repoRoot, ".github", "workflows", "scorecard.yml"),
+  "utf8"
+);
 
 describe("scheduled automation metadata", () => {
   it("schedules dependabot updates deterministically for npm and GitHub Actions", () => {
@@ -75,5 +79,10 @@ describe("scheduled automation metadata", () => {
     expect(codeqlWorkflow).toContain(
       "github/codeql-action/analyze@c10b8064de6f491fea524254123dbe5e09572f13"
     );
+  });
+
+  it("pins the SARIF upload source root for Scorecard results", () => {
+    expect(scorecardWorkflow).toContain("github/codeql-action/upload-sarif");
+    expect(scorecardWorkflow).toContain("checkout_path: $" + "{{ github.workspace }}");
   });
 });


### PR DESCRIPTION
## Summary
- explicitly pass the GitHub workspace as the SARIF upload checkout path for Scorecard results
- add a regression test so the source-root pin does not drift away

## Validation
- pnpm run format
- pnpm run lint
- pnpm test -- automationMetadata