### PR TITLE
feat: show multi-agent task hints

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,6 +21,28 @@ permissions:
   contents: read
 
 jobs:
+  worktree-sync-guard:
+    if: ${{ github.event_name == 'pull_request' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: 22
+
+      - name: Fetch base branch
+        run: git fetch origin "${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}"
+
+      - name: Check PR head contains latest base
+        run: node ./scripts/worktree-sync-guard.mjs --base "origin/${{ github.base_ref }}"
+
   lint:
     runs-on: ubuntu-latest
     strategy:

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ No telemetry. Privacy-first. Security-first.
 - Adds a Beads view in the Activity Bar
 - Lets you switch between Git Graph and Beads from the toolbar
 - Lets you refresh, create, close, and sync Beads items inside VS Code
+- Shows optional parallel, agent, and worktree hints on Beads items
 
 ## Use It
 
@@ -22,6 +23,16 @@ No telemetry. Privacy-first. Security-first.
 3. Use the toolbar to refresh, sync, or switch views.
 
 If your workspace has a `.beads` directory, the extension detects it automatically. Set `beads-git-graph.bdPath` if `bd` is not on `PATH`.
+
+## Multi-Agent Hints
+
+The Beads view surfaces optional execution hints from issue fields or labels:
+
+- `parallelizable: true` or label `parallel-ok`
+- `agent: "agent-a"` or label `agent:agent-a`
+- `worktree: "../repo-agent-a"` or label `worktree:../repo-agent-a`
+
+These hints are visual metadata. Beads ready/blocking behavior still comes from issue status and dependencies.
 
 ## Docs
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,14 @@ The Beads view surfaces optional execution hints from issue fields or labels:
 
 These hints are visual metadata. Beads ready/blocking behavior still comes from issue status and dependencies.
 
+Before merging a multi-agent PR, make sure every agent worktree contains the latest base branch:
+
+```bash
+pnpm run worktree-sync:guard -- --base origin/main
+```
+
+The PR CI also runs the guard against the PR head so stale branches fail before merge.
+
 ## Docs
 
 - [Contributing](./CONTRIBUTING.md)

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "format:fix": "oxfmt .",
     "lint": "oxlint",
     "lint:fix": "oxlint --fix",
+    "worktree-sync:guard": "node scripts/worktree-sync-guard.mjs --all",
     "test": "vitest run",
     "test:watch": "vitest"
   },

--- a/scripts/worktree-sync-guard.mjs
+++ b/scripts/worktree-sync-guard.mjs
@@ -1,0 +1,268 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+
+import { spawnSync } from "node:child_process";
+import { realpathSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export function parseWorktreePorcelain(output) {
+  const worktrees = [];
+  let current = null;
+
+  for (const rawLine of output.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (line === "") {
+      if (current !== null) {
+        worktrees.push(current);
+        current = null;
+      }
+      continue;
+    }
+
+    const [key, ...valueParts] = line.split(" ");
+    const value = valueParts.join(" ");
+    if (key === "worktree") {
+      if (current !== null) {
+        worktrees.push(current);
+      }
+      current = {
+        path: value,
+        branch: "",
+        head: "",
+        bare: false,
+        detached: false
+      };
+      continue;
+    }
+
+    if (current === null) {
+      continue;
+    }
+
+    if (key === "HEAD") {
+      current.head = value;
+    } else if (key === "branch") {
+      current.branch = value.replace(/^refs\/heads\//, "");
+    } else if (key === "bare") {
+      current.bare = true;
+    } else if (key === "detached") {
+      current.detached = true;
+    }
+  }
+
+  if (current !== null) {
+    worktrees.push(current);
+  }
+
+  return worktrees;
+}
+
+export function parseRevListCounts(output) {
+  const [aheadRaw, behindRaw] = output.trim().split(/\s+/);
+  return {
+    ahead: Number.parseInt(aheadRaw || "0", 10) || 0,
+    behind: Number.parseInt(behindRaw || "0", 10) || 0
+  };
+}
+
+export function summarizeFindings(findings) {
+  const failures = findings.filter((finding) => finding.level === "error");
+  const warnings = findings.filter((finding) => finding.level === "warning");
+  return {
+    ok: failures.length === 0,
+    failures,
+    warnings
+  };
+}
+
+function parseArgs(argv) {
+  const options = {
+    all: false,
+    base: "origin/main",
+    cwd: process.cwd(),
+    requireClean: false
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--all") {
+      options.all = true;
+    } else if (arg === "--require-clean") {
+      options.requireClean = true;
+    } else if (arg === "--base") {
+      options.base = argv[i + 1] ?? options.base;
+      i += 1;
+    } else if (arg === "--cwd") {
+      options.cwd = argv[i + 1] ?? options.cwd;
+      i += 1;
+    } else if (arg === "--help" || arg === "-h") {
+      printHelp();
+      process.exit(0);
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  return options;
+}
+
+function printHelp() {
+  console.log(`Usage: node scripts/worktree-sync-guard.mjs [options]
+
+Checks that PR or agent worktrees are synced before merge.
+
+Options:
+  --base <ref>        Base ref that every checked HEAD must contain (default: origin/main)
+  --all               Check every linked git worktree instead of only the current worktree
+  --cwd <path>        Repository path to inspect (default: current directory)
+  --require-clean     Also fail when a checked worktree has uncommitted changes
+`);
+}
+
+function runGit(args, cwd) {
+  return spawnSync("git", args, {
+    cwd,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"]
+  });
+}
+
+function commandText(args) {
+  return `git ${args.join(" ")}`;
+}
+
+function currentWorktree(cwd) {
+  const topLevel = runGit(["rev-parse", "--show-toplevel"], cwd);
+  if (topLevel.status !== 0) {
+    throw new Error(topLevel.stderr.trim() || "Unable to resolve git worktree root.");
+  }
+
+  const branch = runGit(["branch", "--show-current"], cwd);
+  const head = runGit(["rev-parse", "HEAD"], cwd);
+  return [
+    {
+      path: topLevel.stdout.trim(),
+      branch: branch.status === 0 ? branch.stdout.trim() : "",
+      head: head.status === 0 ? head.stdout.trim() : "",
+      bare: false,
+      detached: branch.status !== 0 || branch.stdout.trim() === ""
+    }
+  ];
+}
+
+function listWorktrees(cwd) {
+  const result = runGit(["worktree", "list", "--porcelain"], cwd);
+  if (result.status !== 0) {
+    throw new Error(result.stderr.trim() || "Unable to list git worktrees.");
+  }
+  return parseWorktreePorcelain(result.stdout).filter((worktree) => !worktree.bare);
+}
+
+function checkWorktree(worktree, options) {
+  const findings = [];
+
+  const baseContains = runGit(["merge-base", "--is-ancestor", options.base, "HEAD"], worktree.path);
+  if (baseContains.status === 1) {
+    findings.push({
+      level: "error",
+      path: worktree.path,
+      message: `HEAD does not contain ${options.base}; rebase or merge the latest base before PR merge.`
+    });
+  } else if (baseContains.status !== 0) {
+    findings.push({
+      level: "error",
+      path: worktree.path,
+      message: `${commandText(["merge-base", "--is-ancestor", options.base, "HEAD"])} failed: ${baseContains.stderr.trim()}`
+    });
+  }
+
+  const upstream = runGit(
+    ["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}"],
+    worktree.path
+  );
+  if (upstream.status === 0 && upstream.stdout.trim() !== "") {
+    const counts = runGit(
+      ["rev-list", "--left-right", "--count", "HEAD...@{upstream}"],
+      worktree.path
+    );
+    if (counts.status === 0) {
+      const { behind } = parseRevListCounts(counts.stdout);
+      if (behind > 0) {
+        findings.push({
+          level: "error",
+          path: worktree.path,
+          message: `Local branch is ${behind} commit(s) behind ${upstream.stdout.trim()}; pull/rebase before merge.`
+        });
+      }
+    } else {
+      findings.push({
+        level: "warning",
+        path: worktree.path,
+        message: `${commandText(["rev-list", "--left-right", "--count", "HEAD...@{upstream}"])} failed: ${counts.stderr.trim()}`
+      });
+    }
+  } else {
+    findings.push({
+      level: "warning",
+      path: worktree.path,
+      message: "No upstream branch is configured; only the base ancestry check was applied."
+    });
+  }
+
+  if (options.requireClean) {
+    const status = runGit(["status", "--porcelain"], worktree.path);
+    if (status.status !== 0) {
+      findings.push({
+        level: "error",
+        path: worktree.path,
+        message: `${commandText(["status", "--porcelain"])} failed: ${status.stderr.trim()}`
+      });
+    } else if (status.stdout.trim() !== "") {
+      findings.push({
+        level: "error",
+        path: worktree.path,
+        message: "Worktree has uncommitted changes; commit, stash, or discard them before merge."
+      });
+    }
+  }
+
+  return findings;
+}
+
+function printFindings(worktrees, findings, options) {
+  console.log(
+    `Worktree sync guard checked ${worktrees.length} worktree(s) against ${options.base}.`
+  );
+
+  if (findings.length === 0) {
+    console.log("All checked worktrees contain the base ref.");
+    return;
+  }
+
+  for (const finding of findings) {
+    const prefix = finding.level === "error" ? "ERROR" : "WARNING";
+    console.log(`${prefix}: ${finding.path}: ${finding.message}`);
+  }
+}
+
+function main() {
+  const options = parseArgs(process.argv.slice(2));
+  options.cwd = realpathSync(resolve(options.cwd));
+
+  const worktrees = options.all ? listWorktrees(options.cwd) : currentWorktree(options.cwd);
+  const findings = worktrees.flatMap((worktree) => checkWorktree(worktree, options));
+  const summary = summarizeFindings(findings);
+
+  printFindings(worktrees, findings, options);
+  process.exit(summary.ok ? 0 : 1);
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  try {
+    main();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+}

--- a/src/beadsData.ts
+++ b/src/beadsData.ts
@@ -13,6 +13,9 @@ export interface BeadItem {
   labels: string;
   createdAt: string;
   parentId: string;
+  parallelizable: boolean;
+  agent: string;
+  worktree: string;
 }
 
 export interface BeadHierarchyItem {
@@ -79,6 +82,102 @@ export function beadPickStringArray(
     }
   }
   return fallback;
+}
+
+function beadPickStringTokens(record: Record<string, unknown>, keys: string[]) {
+  const tokens: string[] = [];
+  for (const key of keys) {
+    const value = record[key];
+    if (Array.isArray(value)) {
+      tokens.push(...value.filter((v): v is string => typeof v === "string" && v.trim() !== ""));
+    } else if (typeof value === "string") {
+      tokens.push(...value.split(","));
+    }
+  }
+
+  return tokens.map((token) => token.trim()).filter((token) => token !== "");
+}
+
+function normalizeToken(value: string) {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[_\s]+/g, "-");
+}
+
+function beadPickStringFromTokens(record: Record<string, unknown>, prefixes: string[]) {
+  const normalizedPrefixes = prefixes.map(normalizeToken);
+  for (const token of beadPickStringTokens(record, ["labels", "tags"])) {
+    const trimmed = token.trim();
+    const normalized = normalizeToken(trimmed);
+    for (const prefix of normalizedPrefixes) {
+      if (normalized.startsWith(`${prefix}:`) || normalized.startsWith(`${prefix}=`)) {
+        return trimmed.slice(prefix.length + 1).trim();
+      }
+      if (normalized.startsWith(`${prefix}/`)) {
+        return trimmed.slice(prefix.length + 1).trim();
+      }
+    }
+  }
+
+  return "";
+}
+
+export function beadPickParallelizable(record: Record<string, unknown>) {
+  const directKeys = [
+    "parallelizable",
+    "parallel",
+    "parallel_ok",
+    "parallelOk",
+    "can_parallel",
+    "canParallel",
+    "can_run_parallel",
+    "canRunParallel"
+  ];
+
+  for (const key of directKeys) {
+    const value = record[key];
+    if (typeof value === "boolean") {
+      return value;
+    }
+    if (typeof value === "string") {
+      const normalized = normalizeToken(value);
+      if (["true", "yes", "y", "1", "parallel", "parallel-ok"].includes(normalized)) {
+        return true;
+      }
+      if (["false", "no", "n", "0", "serial", "sequential"].includes(normalized)) {
+        return false;
+      }
+    }
+  }
+
+  const labels = beadPickStringTokens(record, ["labels", "tags"]).map(normalizeToken);
+  if (labels.some((label) => ["serial", "sequential", "no-parallel"].includes(label))) {
+    return false;
+  }
+  return labels.some((label) =>
+    ["parallel", "parallel-ok", "parallelizable", "multi-agent", "multiagent"].includes(label)
+  );
+}
+
+export function beadPickAgent(record: Record<string, unknown>) {
+  const direct = beadPickString(
+    record,
+    ["agent", "agent_id", "agentId", "assigned_agent", "assignedAgent"],
+    ""
+  );
+  return direct !== ""
+    ? direct
+    : beadPickStringFromTokens(record, ["agent", "agent-id", "assigned-agent"]);
+}
+
+export function beadPickWorktree(record: Record<string, unknown>) {
+  const direct = beadPickString(
+    record,
+    ["worktree", "worktree_path", "worktreePath", "worktree_branch", "worktreeBranch"],
+    ""
+  );
+  return direct !== "" ? direct : beadPickStringFromTokens(record, ["worktree", "wt"]);
 }
 
 export function beadPickParentId(record: Record<string, unknown>) {
@@ -186,6 +285,9 @@ export function toBeadItem(item: unknown): BeadItem | null {
     createdAt: beadPickString(record, ["created_at", "createdAt", "created"], "-"),
     updatedAt: beadPickString(record, ["updated_at", "updatedAt", "updated", "modified_at"], "-"),
     parentId: beadPickParentId(record),
+    parallelizable: beadPickParallelizable(record),
+    agent: beadPickAgent(record),
+    worktree: beadPickWorktree(record),
     commitHash: beadPickString(record, ["commitHash", "commit_hash", "commit"], "")
   };
 }
@@ -308,7 +410,10 @@ export function mergeBeadItems(primaryItems: BeadItem[], fallbackItems: BeadItem
     return {
       ...fallback,
       ...item,
-      parentId: item.parentId.trim() !== "" ? item.parentId : fallback.parentId
+      parentId: item.parentId.trim() !== "" ? item.parentId : fallback.parentId,
+      parallelizable: item.parallelizable || fallback.parallelizable,
+      agent: item.agent.trim() !== "" ? item.agent : fallback.agent,
+      worktree: item.worktree.trim() !== "" ? item.worktree : fallback.worktree
     };
   });
 
@@ -341,6 +446,9 @@ export function diffBeadItems(
     "labels",
     "createdAt",
     "parentId",
+    "parallelizable",
+    "agent",
+    "worktree",
     "commitHash"
   ];
   const missingFromPrimary: string[] = [];

--- a/src/beadsWebview.ts
+++ b/src/beadsWebview.ts
@@ -64,13 +64,33 @@ export function renderBeadsWebviewHtml(
                       : 9;
             const prioritySortOrder = parseInt(normalizedPriority.substring(1), 10);
             const shortUpdated = beadShortDate(item.updatedAt);
+            const worktreeLabel =
+              item.worktree === ""
+                ? ""
+                : (item.worktree
+                    .split(/[\\/]/)
+                    .filter((part) => part !== "")
+                    .pop() ?? item.worktree);
+            const executionBadges = [
+              item.parallelizable
+                ? '<span class="executionBadge parallelBadge">Parallel</span>'
+                : "",
+              item.agent === ""
+                ? ""
+                : `<span class="executionBadge agentBadge">Agent ${escapeHtml(item.agent)}</span>`,
+              worktreeLabel === ""
+                ? ""
+                : `<span class="executionBadge worktreeBadge">WT ${escapeHtml(worktreeLabel)}</span>`
+            ]
+              .filter((badge) => badge !== "")
+              .join("");
             const serializedItem = {
               ...item,
               parentId: parentId ?? "",
               epicId: epicId ?? ""
             };
             const treeWidth = depth > 0 ? depth * 18 : 0;
-            return `<tr class="beadRow" data-id="${escapeHtml(item.id)}" data-workspace-path="${escapeHtml(group.workspacePath)}" data-parent-id="${escapeHtml(parentId ?? "")}" data-epic-id="${escapeHtml(epicId ?? "")}" data-depth="${depth}" data-order-index="${orderIndex}" data-guide-columns="${guideColumns.map((value) => (value ? "1" : "0")).join("")}" data-last-sibling="${isLastSibling ? "1" : "0"}" data-status="${escapeHtml(normalizedStatus)}" data-item="${escapeHtml(encodeURIComponent(JSON.stringify(serializedItem)))}" data-updated-ts="${updatedTs}" data-type-sort="${typeSortOrder}" data-priority-sort="${Number.isNaN(prioritySortOrder) ? 9 : prioritySortOrder}"><td><span class="typeBadge type-${escapeHtml(normalizedType)}">${escapeHtml(item.type)}</span></td><td><div class="titleCell" style="--tree-width:${treeWidth}px"><div class="titleContent"><div class="beadId">${escapeHtml(item.id)}</div><div class="beadTitle">${escapeHtml(item.title)}</div></div></div></td><td><div class="statusCell"><span class="statusBadge status-${escapeHtml(normalizedStatus.replace(/_/g, "-"))}">${escapeHtml(statusLabel)}</span>${progressLabel === "" ? "" : `<span class="progressText">${escapeHtml(progressLabel)}</span>`}</div></td><td><span class="priorityBadge priority-${escapeHtml(normalizedPriority.toLowerCase())}">${escapeHtml(normalizedPriority)}</span></td><td class="updatedCell" title="${escapeHtml(item.updatedAt)}">${escapeHtml(shortUpdated)}</td></tr>`;
+            return `<tr class="beadRow" data-id="${escapeHtml(item.id)}" data-workspace-path="${escapeHtml(group.workspacePath)}" data-parent-id="${escapeHtml(parentId ?? "")}" data-epic-id="${escapeHtml(epicId ?? "")}" data-depth="${depth}" data-order-index="${orderIndex}" data-guide-columns="${guideColumns.map((value) => (value ? "1" : "0")).join("")}" data-last-sibling="${isLastSibling ? "1" : "0"}" data-status="${escapeHtml(normalizedStatus)}" data-item="${escapeHtml(encodeURIComponent(JSON.stringify(serializedItem)))}" data-updated-ts="${updatedTs}" data-type-sort="${typeSortOrder}" data-priority-sort="${Number.isNaN(prioritySortOrder) ? 9 : prioritySortOrder}"><td><span class="typeBadge type-${escapeHtml(normalizedType)}">${escapeHtml(item.type)}</span></td><td><div class="titleCell" style="--tree-width:${treeWidth}px"><div class="titleContent"><div class="beadId">${escapeHtml(item.id)}</div><div class="beadTitle">${escapeHtml(item.title)}</div>${executionBadges === "" ? "" : `<div class="beadMeta">${executionBadges}</div>`}</div></div></td><td><div class="statusCell"><span class="statusBadge status-${escapeHtml(normalizedStatus.replace(/_/g, "-"))}">${escapeHtml(statusLabel)}</span>${progressLabel === "" ? "" : `<span class="progressText">${escapeHtml(progressLabel)}</span>`}</div></td><td><span class="priorityBadge priority-${escapeHtml(normalizedPriority.toLowerCase())}">${escapeHtml(normalizedPriority)}</span></td><td class="updatedCell" title="${escapeHtml(item.updatedAt)}">${escapeHtml(shortUpdated)}</td></tr>`;
           })
           .join("");
 
@@ -168,6 +188,11 @@ th:nth-child(1){width:52px;}th:nth-child(3){width:78px;}th:nth-child(4){width:56
 .hierarchyGuideNodeShadow{fill:rgba(0,0,0,.22);vector-effect:non-scaling-stroke;opacity:.4;}
 .hierarchyGuideNode{fill:var(--vscode-textLink-foreground, #4da3ff);vector-effect:non-scaling-stroke;opacity:1;}
 .beadTitle{font-size:13px;font-weight:600;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}
+.beadMeta{display:flex;align-items:center;gap:4px;flex-wrap:wrap;margin-top:3px;}
+.executionBadge{display:inline-flex;align-items:center;max-width:100%;padding:1px 5px;border-radius:6px;border:1px solid rgba(128,128,128,.42);font-size:10px;font-weight:650;line-height:14px;color:var(--vscode-descriptionForeground);background:rgba(128,128,128,.1);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}
+.parallelBadge{border-color:rgba(34,197,94,.55);color:var(--vscode-testing-iconPassed, #22c55e);background:rgba(34,197,94,.12);}
+.agentBadge{border-color:rgba(59,130,246,.55);color:var(--vscode-textLink-foreground, #3b82f6);background:rgba(59,130,246,.12);}
+.worktreeBadge{border-color:rgba(234,179,8,.55);color:var(--vscode-charts-yellow, #d97706);background:rgba(234,179,8,.12);}
 .statusCell{display:flex;align-items:center;gap:6px;flex-wrap:wrap;}
 .typeBadge,.statusBadge,.priorityBadge{display:inline-flex;align-items:center;justify-content:center;padding:1px 5px;border-radius:999px;font-size:10px;font-weight:600;white-space:nowrap;}
 .priorityBadge{min-width:34px;}

--- a/src/beadsWebview.ts
+++ b/src/beadsWebview.ts
@@ -238,8 +238,6 @@ th:nth-child(1){width:52px;}th:nth-child(3){width:78px;}th:nth-child(4){width:56
 .beadRow:hover{background:rgba(128,128,128,.08);}
 .beadRow.selected{background:rgba(59,130,246,.16);}
 .beadRow.selected td:first-child{box-shadow:inset 3px 0 0 var(--vscode-textLink-foreground,#3b82f6);}
-.beadRow[data-status="blocked"]:not(.selected) td:first-child{box-shadow:inset 3px 0 0 var(--vscode-errorForeground,#ef4444);}
-.beadRow[data-status="in_progress"]:not(.selected) td:first-child{box-shadow:inset 3px 0 0 #3b82f6;}
 .beadId{font-size:10px;color:var(--vscode-descriptionForeground);margin-bottom:2px;}
 .titleCell{position:relative;display:flex;align-items:flex-start;gap:6px;min-width:0;padding-left:calc(var(--tree-width, 0px) + 4px);}
 .titleContent{min-width:0;flex:1 1 auto;}
@@ -250,6 +248,7 @@ th:nth-child(1){width:52px;}th:nth-child(3){width:78px;}th:nth-child(4){width:56
 .collapseSpacer{flex:0 0 18px;width:18px;height:18px;}
 .hierarchyGuideShadow{fill:none;stroke:rgba(0,0,0,.18);stroke-width:3.8;stroke-linecap:round;stroke-linejoin:round;vector-effect:non-scaling-stroke;opacity:.45;}
 .hierarchyGuideLine{fill:none;stroke:var(--vscode-textLink-foreground, #4da3ff);stroke-width:2.1;stroke-linecap:round;stroke-linejoin:round;vector-effect:non-scaling-stroke;opacity:1;}
+.hierarchyGuideVertical{stroke-linecap:butt;}
 .hierarchyGuideNodeShadow{fill:rgba(0,0,0,.22);vector-effect:non-scaling-stroke;opacity:.4;}
 .hierarchyGuideNode{fill:var(--vscode-textLink-foreground, #4da3ff);vector-effect:non-scaling-stroke;opacity:1;}
 .beadTitle{font-size:13px;font-weight:650;line-height:1.25;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}

--- a/src/beadsWebview.ts
+++ b/src/beadsWebview.ts
@@ -41,7 +41,50 @@ export function renderBeadsWebviewHtml(
   } else {
     const populatedHtml = rows
       .map((group) => {
-        const itemRows = flattenBeadHierarchy(group.items)
+        const flatItems = flattenBeadHierarchy(group.items);
+        const childCountByParent = new Map<string, number>();
+        let activeCount = 0;
+        let blockedCount = 0;
+        let parallelCount = 0;
+        const agents = new Set<string>();
+        for (const entry of flatItems) {
+          const status = normalizeBeadStatus(entry.item.status);
+          if (status === "open" || status === "in_progress" || status === "blocked") {
+            activeCount += 1;
+          }
+          if (status === "blocked") {
+            blockedCount += 1;
+          }
+          if (entry.item.parallelizable) {
+            parallelCount += 1;
+          }
+          if (entry.item.agent.trim() !== "") {
+            agents.add(entry.item.agent.trim());
+          }
+          if (entry.parentId !== null) {
+            childCountByParent.set(
+              entry.parentId,
+              (childCountByParent.get(entry.parentId) ?? 0) + 1
+            );
+          }
+        }
+        const workspaceTitle = showWorkspaceLabel ? group.workspace : "Beads";
+        const workspaceSummary = [
+          `<span class="summaryPill">${flatItems.length} total</span>`,
+          `<span class="summaryPill activeSummary">${activeCount} active</span>`,
+          blockedCount > 0
+            ? `<span class="summaryPill blockedSummary">${blockedCount} blocked</span>`
+            : "",
+          parallelCount > 0
+            ? `<span class="summaryPill parallelSummary">${parallelCount} parallel</span>`
+            : "",
+          agents.size > 0
+            ? `<span class="summaryPill agentSummary">${agents.size} agents</span>`
+            : ""
+        ]
+          .filter((pill) => pill !== "")
+          .join("");
+        const itemRows = flatItems
           .map(({ item, parentId, epicId, depth, orderIndex, guideColumns, isLastSibling }) => {
             const normalizedStatus = normalizeBeadStatus(item.status);
             const statusLabel = beadStatusLabel(normalizedStatus);
@@ -90,11 +133,17 @@ export function renderBeadsWebviewHtml(
               epicId: epicId ?? ""
             };
             const treeWidth = depth > 0 ? depth * 18 : 0;
-            return `<tr class="beadRow" data-id="${escapeHtml(item.id)}" data-workspace-path="${escapeHtml(group.workspacePath)}" data-parent-id="${escapeHtml(parentId ?? "")}" data-epic-id="${escapeHtml(epicId ?? "")}" data-depth="${depth}" data-order-index="${orderIndex}" data-guide-columns="${guideColumns.map((value) => (value ? "1" : "0")).join("")}" data-last-sibling="${isLastSibling ? "1" : "0"}" data-status="${escapeHtml(normalizedStatus)}" data-item="${escapeHtml(encodeURIComponent(JSON.stringify(serializedItem)))}" data-updated-ts="${updatedTs}" data-type-sort="${typeSortOrder}" data-priority-sort="${Number.isNaN(prioritySortOrder) ? 9 : prioritySortOrder}"><td><span class="typeBadge type-${escapeHtml(normalizedType)}">${escapeHtml(item.type)}</span></td><td><div class="titleCell" style="--tree-width:${treeWidth}px"><div class="titleContent"><div class="beadId">${escapeHtml(item.id)}</div><div class="beadTitle">${escapeHtml(item.title)}</div>${executionBadges === "" ? "" : `<div class="beadMeta">${executionBadges}</div>`}</div></div></td><td><div class="statusCell"><span class="statusBadge status-${escapeHtml(normalizedStatus.replace(/_/g, "-"))}">${escapeHtml(statusLabel)}</span>${progressLabel === "" ? "" : `<span class="progressText">${escapeHtml(progressLabel)}</span>`}</div></td><td><span class="priorityBadge priority-${escapeHtml(normalizedPriority.toLowerCase())}">${escapeHtml(normalizedPriority)}</span></td><td class="updatedCell" title="${escapeHtml(item.updatedAt)}">${escapeHtml(shortUpdated)}</td></tr>`;
+            const childCount = childCountByParent.get(item.id) ?? 0;
+            const rowClasses = childCount > 0 ? "beadRow hasChildren" : "beadRow";
+            const hierarchyToggle =
+              childCount > 0
+                ? `<button class="collapseToggle" type="button" aria-expanded="true" title="Toggle subprojects"><span class="collapseIcon" aria-hidden="true">▾</span></button>`
+                : '<span class="collapseSpacer" aria-hidden="true"></span>';
+            return `<tr class="${rowClasses}" data-id="${escapeHtml(item.id)}" data-workspace-path="${escapeHtml(group.workspacePath)}" data-parent-id="${escapeHtml(parentId ?? "")}" data-epic-id="${escapeHtml(epicId ?? "")}" data-depth="${depth}" data-child-count="${childCount}" data-order-index="${orderIndex}" data-guide-columns="${guideColumns.map((value) => (value ? "1" : "0")).join("")}" data-last-sibling="${isLastSibling ? "1" : "0"}" data-status="${escapeHtml(normalizedStatus)}" data-item="${escapeHtml(encodeURIComponent(JSON.stringify(serializedItem)))}" data-updated-ts="${updatedTs}" data-type-sort="${typeSortOrder}" data-priority-sort="${Number.isNaN(prioritySortOrder) ? 9 : prioritySortOrder}"><td><span class="typeBadge type-${escapeHtml(normalizedType)}">${escapeHtml(item.type)}</span></td><td><div class="titleCell" style="--tree-width:${treeWidth}px">${hierarchyToggle}<div class="titleContent"><div class="beadId">${escapeHtml(item.id)}</div><div class="beadTitle">${escapeHtml(item.title)}</div>${executionBadges === "" ? "" : `<div class="beadMeta">${executionBadges}</div>`}</div></div></td><td><div class="statusCell"><span class="statusBadge status-${escapeHtml(normalizedStatus.replace(/_/g, "-"))}">${escapeHtml(statusLabel)}</span>${progressLabel === "" ? "" : `<span class="progressText">${escapeHtml(progressLabel)}</span>`}</div></td><td><span class="priorityBadge priority-${escapeHtml(normalizedPriority.toLowerCase())}">${escapeHtml(normalizedPriority)}</span></td><td class="updatedCell" title="${escapeHtml(item.updatedAt)}">${escapeHtml(shortUpdated)}</td></tr>`;
           })
           .join("");
 
-        return `<section data-workspace-path="${escapeHtml(group.workspacePath)}">${showWorkspaceLabel ? `<div class="meta"><strong>${escapeHtml(group.workspace)}</strong></div>` : ""}<div class="tableWrap"><svg class="hierarchyOverlay" aria-hidden="true"></svg><table><thead><tr><th><button class="sortToggle" data-sort-key="type" type="button" title="Sort by type">Type <span class="sortIcon" data-sort-key="type"> </span></button></th><th>Title</th><th>Status</th><th><button class="sortToggle" data-sort-key="priority" type="button" title="Sort by priority">Priority <span class="sortIcon" data-sort-key="priority"> </span></button></th><th><button class="sortToggle" data-sort-key="updated" type="button" title="Sort by updated">Updated <span class="sortIcon" data-sort-key="updated">▼</span></button></th></tr></thead><tbody>${itemRows}</tbody></table></div></section>`;
+        return `<section data-workspace-path="${escapeHtml(group.workspacePath)}"><div class="workspaceHeader"><div class="workspaceName">${escapeHtml(workspaceTitle)}</div><div class="workspaceSummary">${workspaceSummary}</div></div><div class="tableWrap"><svg class="hierarchyOverlay" aria-hidden="true"></svg><table><thead><tr><th><button class="sortToggle" data-sort-key="type" type="button" title="Sort by type">Type <span class="sortIcon" data-sort-key="type"> </span></button></th><th>Title</th><th>Status</th><th><button class="sortToggle" data-sort-key="priority" type="button" title="Sort by priority">Priority <span class="sortIcon" data-sort-key="priority"> </span></button></th><th><button class="sortToggle" data-sort-key="updated" type="button" title="Sort by updated">Updated <span class="sortIcon" data-sort-key="updated">▼</span></button></th></tr></thead><tbody>${itemRows}</tbody></table></div></section>`;
       })
       .join("");
     const emptyHtml = result.emptyWorkspaces
@@ -129,22 +178,22 @@ export function renderBeadsWebviewHtml(
 <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src ${webview.cspSource} 'unsafe-inline'; script-src ${webview.cspSource} 'nonce-${nonce}';">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <style>
-body{font-family:var(--vscode-font-family);color:var(--vscode-foreground);padding:4px;background:var(--vscode-editor-background);}
-.toolbar{display:grid;grid-template-columns:minmax(0,1fr) auto;align-items:start;gap:8px;margin-bottom:2px;}
+body{font-family:var(--vscode-font-family);color:var(--vscode-foreground);padding:6px;background:var(--vscode-editor-background);font-size:13px;}
+.toolbar{display:grid;grid-template-columns:minmax(0,1fr) auto;align-items:start;gap:8px;margin-bottom:6px;padding:6px;border:1px solid var(--vscode-panel-border);border-radius:8px;background:var(--vscode-sideBar-background,var(--vscode-editor-background));box-shadow:0 1px 4px rgba(0,0,0,.12);}
 .toolbarMain{display:flex;align-items:center;gap:6px;flex-wrap:wrap;min-width:0;}
 .toolbarActions{display:flex;align-items:center;justify-content:flex-end;gap:8px;flex:0 0 auto;}
-.toolbarStatsRow{display:flex;justify-content:flex-end;margin:0 0 6px;}
+.toolbarStatsRow{display:flex;justify-content:flex-end;margin:0 0 8px;}
 .preset{height:24px;background:var(--vscode-dropdown-background);color:var(--vscode-dropdown-foreground);border:1px solid var(--vscode-dropdown-border, var(--vscode-panel-border));border-radius:6px;padding:0 6px;font-size:11px;}
 .chips{display:flex;gap:6px;flex-wrap:wrap;}
 .chips:empty{display:none;}
-.chip{display:inline-flex;align-items:center;gap:6px;padding:3px 8px;border-radius:999px;font-size:11px;border:1px solid var(--vscode-panel-border);background:rgba(128,128,128,.12);}
+.chip{display:inline-flex;align-items:center;gap:6px;min-height:20px;padding:2px 8px;border-radius:999px;font-size:11px;border:1px solid var(--vscode-panel-border);background:rgba(128,128,128,.12);}
 .chip .remove{background:transparent;border:none;color:inherit;cursor:pointer;line-height:1;padding:0;font-size:12px;opacity:.8;}
 .chip.status-open{border-left:3px solid #10b981;}
 .chip.status-in_progress{border-left:3px solid #3b82f6;}
 .chip.status-blocked{border-left:3px solid #ef4444;}
 .chip.status-closed{border-left:3px solid #6b7280;}
 .menu{position:relative;}
-.menuPopup{display:none;position:absolute;top:30px;left:0;z-index:20;min-width:140px;background:var(--vscode-menu-background);border:1px solid var(--vscode-menu-border, var(--vscode-panel-border));box-shadow:0 2px 8px var(--vscode-widget-shadow);padding:6px;}
+.menuPopup{display:none;position:absolute;top:30px;left:0;z-index:20;min-width:140px;background:var(--vscode-menu-background);border:1px solid var(--vscode-menu-border, var(--vscode-panel-border));box-shadow:0 4px 14px var(--vscode-widget-shadow);padding:6px;border-radius:8px;}
 .menuPopup.open{display:block;}
 .menuPopup button{display:block;width:100%;margin:2px 0;text-align:left;background:transparent;color:var(--vscode-menu-foreground);border:1px solid transparent;padding:4px 6px;border-radius:4px;}
 .menuPopup button:hover{background:var(--vscode-menu-selectionBackground);color:var(--vscode-menu-selectionForeground);}
@@ -155,7 +204,7 @@ body{font-family:var(--vscode-font-family);color:var(--vscode-foreground);paddin
 .contextMenu button:disabled{opacity:.45;cursor:default;}
 button{border:1px solid var(--vscode-button-border,transparent);background:var(--vscode-button-background);color:var(--vscode-button-foreground);padding:4px 8px;cursor:pointer;border-radius:6px;font-size:11px;}
 button:hover{background:var(--vscode-button-hoverBackground);}
-.actionBtn{display:inline-flex;align-items:center;justify-content:center;height:24px;padding:0 10px;border-radius:11px;background:rgba(128,128,128,.1);border:1px solid rgba(128,128,128,.5);gap:6px;transition:border-color .18s ease, background-color .18s ease, box-shadow .18s ease;}
+.actionBtn{display:inline-flex;align-items:center;justify-content:center;height:24px;padding:0 10px;border-radius:6px;background:rgba(128,128,128,.1);border:1px solid rgba(128,128,128,.5);gap:6px;transition:border-color .18s ease, background-color .18s ease, box-shadow .18s ease;}
 .actionBtn:hover{background:rgba(128,128,128,.2);}
 #syncBeads{min-width:68px;}
 body[data-has-sync-warnings="1"] #syncBeads{border-color:var(--vscode-editorWarning-foreground, #f59e0b);background:rgba(245,158,11,.18);box-shadow:0 0 0 0 rgba(245,158,11,.32);animation:syncPulse 1.4s ease-in-out infinite;}
@@ -167,34 +216,50 @@ body[data-has-sync-warnings="1"] #syncBeads .toolbarActionLabel{font-weight:700;
 .toolbarIcon.switchIcon{width:18px;height:18px;}
 .toolbarIcon.refreshIcon{width:18px;height:18px;}
 .toolbarActionLabel{color:var(--vscode-button-foreground);font-size:11px;line-height:1;}
-.meta{display:grid;grid-template-columns:1fr;font-size:11px;opacity:.9;margin:6px 0 4px;gap:6px;align-items:center;}
-section{margin-bottom:10px;}
-.tableWrap{position:relative;}
+.workspaceHeader{display:flex;align-items:center;justify-content:space-between;gap:8px;margin:8px 0 5px;min-width:0;}
+.workspaceName{font-size:12px;font-weight:700;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
+.workspaceSummary{display:flex;justify-content:flex-end;gap:4px;flex-wrap:wrap;}
+.summaryPill{display:inline-flex;align-items:center;min-height:18px;padding:1px 6px;border:1px solid var(--vscode-panel-border);border-radius:999px;background:rgba(128,128,128,.1);color:var(--vscode-descriptionForeground);font-size:10px;font-weight:600;white-space:nowrap;}
+.activeSummary{border-color:rgba(59,130,246,.4);color:var(--vscode-textLink-foreground,#3b82f6);}
+.blockedSummary{border-color:rgba(239,68,68,.5);color:var(--vscode-errorForeground,#ef4444);}
+.parallelSummary{border-color:rgba(34,197,94,.45);color:var(--vscode-testing-iconPassed,#22c55e);}
+.agentSummary{border-color:rgba(234,179,8,.5);color:var(--vscode-charts-yellow,#d97706);}
+section{margin-bottom:12px;}
+.tableWrap{position:relative;border:1px solid var(--vscode-panel-border);border-radius:8px;overflow:hidden;background:var(--vscode-editor-background);}
 .hierarchyOverlay{position:absolute;inset:0;z-index:0;width:100%;height:100%;pointer-events:none;overflow:visible;}
-table{position:relative;z-index:1;width:100%;border-collapse:collapse;font-size:13px;table-layout:fixed;}
-th,td{text-align:left;border-bottom:1px solid var(--vscode-panel-border);padding:4px 4px;vertical-align:middle;font-size:13px;}
-th{position:sticky;top:0;z-index:2;font-weight:700;line-height:18px;padding:6px 4px;opacity:.95;background:var(--vscode-editor-background);box-shadow:0 1px 0 var(--vscode-panel-border);}
+table{position:relative;z-index:1;width:100%;border-collapse:separate;border-spacing:0;font-size:13px;table-layout:fixed;}
+th,td{text-align:left;border-bottom:1px solid var(--vscode-panel-border);padding:6px 5px;vertical-align:middle;font-size:13px;}
+tbody tr:last-child td{border-bottom:none;}
+th{position:sticky;top:0;z-index:2;font-weight:700;line-height:18px;padding:6px 5px;opacity:.95;background:var(--vscode-sideBar-background,var(--vscode-editor-background));box-shadow:0 1px 0 var(--vscode-panel-border);}
 th:nth-child(1){width:52px;}th:nth-child(3){width:78px;}th:nth-child(4){width:56px;}th:nth-child(5){width:84px;}
 .sortToggle{display:inline-flex;align-items:center;justify-content:flex-start;width:100%;gap:4px;background:transparent;border:none;color:inherit;padding:0;cursor:pointer;font:inherit;}
 .sortToggle:hover{text-decoration:underline;}
-.beadRow{cursor:pointer;}
+.beadRow{cursor:pointer;transition:background-color .12s ease;}
 .beadRow:hover{background:rgba(128,128,128,.08);}
-.beadRow.selected{background:rgba(128,128,128,.18);}
-.beadId{font-size:10px;color:var(--vscode-descriptionForeground);margin-bottom:1px;}
-.titleCell{position:relative;min-width:0;padding-left:calc(var(--tree-width, 0px) + 4px);}
-.titleContent{min-width:0;}
+.beadRow.selected{background:rgba(59,130,246,.16);}
+.beadRow.selected td:first-child{box-shadow:inset 3px 0 0 var(--vscode-textLink-foreground,#3b82f6);}
+.beadRow[data-status="blocked"]:not(.selected) td:first-child{box-shadow:inset 3px 0 0 var(--vscode-errorForeground,#ef4444);}
+.beadRow[data-status="in_progress"]:not(.selected) td:first-child{box-shadow:inset 3px 0 0 #3b82f6;}
+.beadId{font-size:10px;color:var(--vscode-descriptionForeground);margin-bottom:2px;}
+.titleCell{position:relative;display:flex;align-items:flex-start;gap:6px;min-width:0;padding-left:calc(var(--tree-width, 0px) + 4px);}
+.titleContent{min-width:0;flex:1 1 auto;}
+.collapseToggle{display:inline-flex;align-items:center;justify-content:center;flex:0 0 18px;width:18px;height:18px;margin-top:1px;padding:0;border-radius:5px;border:1px solid transparent;background:transparent;color:var(--vscode-descriptionForeground);}
+.collapseToggle:hover{border-color:var(--vscode-panel-border);background:rgba(128,128,128,.12);}
+.collapseToggle[aria-expanded="false"] .collapseIcon{transform:rotate(-90deg);}
+.collapseIcon{display:block;line-height:1;transition:transform .12s ease;}
+.collapseSpacer{flex:0 0 18px;width:18px;height:18px;}
 .hierarchyGuideShadow{fill:none;stroke:rgba(0,0,0,.18);stroke-width:3.8;stroke-linecap:round;stroke-linejoin:round;vector-effect:non-scaling-stroke;opacity:.45;}
 .hierarchyGuideLine{fill:none;stroke:var(--vscode-textLink-foreground, #4da3ff);stroke-width:2.1;stroke-linecap:round;stroke-linejoin:round;vector-effect:non-scaling-stroke;opacity:1;}
 .hierarchyGuideNodeShadow{fill:rgba(0,0,0,.22);vector-effect:non-scaling-stroke;opacity:.4;}
 .hierarchyGuideNode{fill:var(--vscode-textLink-foreground, #4da3ff);vector-effect:non-scaling-stroke;opacity:1;}
-.beadTitle{font-size:13px;font-weight:600;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}
-.beadMeta{display:flex;align-items:center;gap:4px;flex-wrap:wrap;margin-top:3px;}
-.executionBadge{display:inline-flex;align-items:center;max-width:100%;padding:1px 5px;border-radius:6px;border:1px solid rgba(128,128,128,.42);font-size:10px;font-weight:650;line-height:14px;color:var(--vscode-descriptionForeground);background:rgba(128,128,128,.1);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}
+.beadTitle{font-size:13px;font-weight:650;line-height:1.25;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}
+.beadMeta{display:flex;align-items:center;gap:4px;flex-wrap:wrap;margin-top:4px;}
+.executionBadge{display:inline-flex;align-items:center;max-width:100%;padding:1px 6px;border-radius:6px;border:1px solid rgba(128,128,128,.42);font-size:10px;font-weight:650;line-height:15px;color:var(--vscode-descriptionForeground);background:rgba(128,128,128,.1);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}
 .parallelBadge{border-color:rgba(34,197,94,.55);color:var(--vscode-testing-iconPassed, #22c55e);background:rgba(34,197,94,.12);}
 .agentBadge{border-color:rgba(59,130,246,.55);color:var(--vscode-textLink-foreground, #3b82f6);background:rgba(59,130,246,.12);}
 .worktreeBadge{border-color:rgba(234,179,8,.55);color:var(--vscode-charts-yellow, #d97706);background:rgba(234,179,8,.12);}
 .statusCell{display:flex;align-items:center;gap:6px;flex-wrap:wrap;}
-.typeBadge,.statusBadge,.priorityBadge{display:inline-flex;align-items:center;justify-content:center;padding:1px 5px;border-radius:999px;font-size:10px;font-weight:600;white-space:nowrap;}
+.typeBadge,.statusBadge,.priorityBadge{display:inline-flex;align-items:center;justify-content:center;padding:1px 6px;border-radius:6px;font-size:10px;font-weight:650;white-space:nowrap;}
 .priorityBadge{min-width:34px;}
 .progressText{font-size:10px;font-weight:700;color:var(--vscode-textLink-foreground);white-space:nowrap;}
 .type-feature{background:#16a34a;color:#fff;}
@@ -221,11 +286,41 @@ th:nth-child(1){width:52px;}th:nth-child(3){width:78px;}th:nth-child(4){width:56
 .commitLink{font-size:11px;padding:2px 6px;}
 .stats{font-size:11px;opacity:.85;margin:0;white-space:nowrap;}
 .inlineDetailsRow td{padding:0 4px 8px;border-bottom:none;}
-.details{margin:0;padding:8px;border:1px solid var(--vscode-panel-border);font-size:12px;background:var(--vscode-editor-background);border-radius:6px;}
-.details h3{margin:0 0 6px;font-size:13px;}
-.detailsGrid{display:grid;grid-template-columns:100px 1fr;gap:4px 8px;}
-.detailsGrid .key{opacity:.75;}
-.detailsDescription{margin-top:8px;white-space:pre-wrap;line-height:1.4;}
+.details{margin:0;padding:10px;border:1px solid var(--vscode-panel-border);font-size:12px;background:var(--vscode-sideBar-background,var(--vscode-editor-background));border-radius:8px;box-shadow:0 1px 4px rgba(0,0,0,.1);}
+.detailsHeader{display:grid;gap:4px;margin-bottom:8px;}
+.detailsTitle{font-size:13px;font-weight:700;line-height:1.3;}
+.detailsId{color:var(--vscode-descriptionForeground);font-size:11px;}
+.detailsPills{display:flex;flex-wrap:wrap;gap:4px;}
+.detailPill{display:inline-flex;align-items:center;min-height:18px;padding:1px 6px;border-radius:6px;border:1px solid var(--vscode-panel-border);background:rgba(128,128,128,.1);font-size:10px;font-weight:650;color:var(--vscode-descriptionForeground);}
+.detailsGrid{display:grid;grid-template-columns:minmax(80px,110px) minmax(0,1fr);gap:5px 10px;}
+.detailsGrid .key{opacity:.78;font-size:11px;}
+.detailsGrid div:nth-child(2n){min-width:0;overflow-wrap:anywhere;}
+.detailsDescription{margin-top:8px;padding-top:8px;border-top:1px solid var(--vscode-panel-border);white-space:pre-wrap;line-height:1.45;}
+@media (max-width:560px){
+  .toolbar{grid-template-columns:1fr;gap:6px;}
+  .toolbarActions{justify-content:stretch;}
+  .toolbarActions .actionBtn{flex:1 1 0;min-width:0;}
+  .workspaceHeader{align-items:flex-start;flex-direction:column;gap:4px;}
+  .workspaceSummary{justify-content:flex-start;}
+  .hierarchyOverlay{display:none;}
+  table,tbody{display:block;}
+  thead{display:none;}
+  .beadRow{display:grid;grid-template-columns:48px minmax(0,1fr) 44px 74px;grid-template-areas:"type title title title" "type status priority updated";gap:4px 6px;padding:7px 6px;border-bottom:1px solid var(--vscode-panel-border);}
+  .beadRow td{display:flex;align-items:center;min-width:0;border-bottom:none;padding:0;}
+  .beadRow td:first-child{grid-area:type;align-items:flex-start;padding-top:2px;}
+  .beadRow td:nth-child(2){grid-area:title;}
+  .beadRow td:nth-child(3){grid-area:status;}
+  .beadRow td:nth-child(4){grid-area:priority;}
+  .beadRow td:nth-child(5){grid-area:updated;justify-content:flex-end;}
+  .titleCell{width:100%;padding-left:calc(var(--tree-width, 0px) * .65);}
+  .beadTitle{white-space:normal;overflow:hidden;}
+  .executionBadge{max-width:132px;}
+  .statusCell{gap:4px;}
+  .updatedCell{text-align:right;}
+  .inlineDetailsRow{display:block;}
+  .inlineDetailsRow td{display:block;padding:0 6px 8px;}
+  .detailsGrid{grid-template-columns:82px minmax(0,1fr);}
+}
 code{font-family:var(--vscode-editor-font-family);}
 </style>
 </head>

--- a/tests/automationMetadata.test.ts
+++ b/tests/automationMetadata.test.ts
@@ -88,6 +88,14 @@ describe("scheduled automation metadata", () => {
     expect(ciWorkflow).toContain("inputs.run_cross_platform == true");
   });
 
+  it("blocks stale multi-agent PR heads before merge", () => {
+    expect(ciWorkflow).toContain("worktree-sync-guard:");
+    expect(ciWorkflow).toContain("github.event.pull_request.head.sha");
+    expect(ciWorkflow).toContain("Fetch base branch");
+    expect(ciWorkflow).toContain("node ./scripts/worktree-sync-guard.mjs");
+    expect(ciWorkflow).toContain("origin/${" + "{ github.base_ref }}");
+  });
+
   it("pins the SARIF upload source root for Scorecard results", () => {
     expect(scorecardWorkflow).toContain("github/codeql-action/upload-sarif");
     expect(scorecardWorkflow).toContain("checkout_path: $" + "{{ github.workspace }}");

--- a/tests/beadsData.test.ts
+++ b/tests/beadsData.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  beadPickAgent,
+  beadPickParallelizable,
   beadPickParentId,
   beadPickProgress,
+  beadPickWorktree,
   beadsAsArray,
   beadShortDate,
   beadStatusLabel,
@@ -67,7 +70,39 @@ describe("toBeadItem", () => {
       createdAt: "2026-03-07T00:00:00Z",
       updatedAt: "2026-03-07T01:00:00Z",
       parentId: "",
+      parallelizable: false,
+      agent: "",
+      worktree: "",
       commitHash: "abcdef1234567"
+    });
+  });
+
+  it("extracts multi-agent execution metadata from fields and labels", () => {
+    expect(
+      toBeadItem({
+        id: "neo-agent-task",
+        title: "Implement shard",
+        issue_type: "task",
+        parallelizable: true,
+        agent: "agent-a",
+        worktree: "../beads-git-graph-agent-a"
+      })
+    ).toMatchObject({
+      parallelizable: true,
+      agent: "agent-a",
+      worktree: "../beads-git-graph-agent-a"
+    });
+
+    expect(
+      toBeadItem({
+        id: "neo-agent-labels",
+        title: "Implement label shard",
+        labels: ["parallel-ok", "agent:agent-b", "worktree:../beads-git-graph-agent-b"]
+      })
+    ).toMatchObject({
+      parallelizable: true,
+      agent: "agent-b",
+      worktree: "../beads-git-graph-agent-b"
     });
   });
 
@@ -313,6 +348,34 @@ describe("buildBeadHierarchy", () => {
       changed: [{ id: "neo-sync-a", fields: ["status"] }]
     });
   });
+
+  it("preserves execution metadata from issues.jsonl when CLI rows omit it", () => {
+    const cliItems = extractBeadItems([
+      {
+        id: "neo-agent-task",
+        title: "Task from CLI",
+        issue_type: "task",
+        updated_at: "2026-03-10T00:00:00Z"
+      }
+    ]);
+    const jsonlItems = extractBeadItems([
+      {
+        id: "neo-agent-task",
+        title: "Task from CLI",
+        issue_type: "task",
+        updated_at: "2026-03-10T00:00:00Z",
+        parallelizable: true,
+        agent: "agent-a",
+        worktree: "../beads-git-graph-agent-a"
+      }
+    ]);
+
+    expect(mergeBeadItems(cliItems, jsonlItems)[0]).toMatchObject({
+      parallelizable: true,
+      agent: "agent-a",
+      worktree: "../beads-git-graph-agent-a"
+    });
+  });
 });
 
 describe("bead normalization helpers", () => {
@@ -326,6 +389,13 @@ describe("bead normalization helpers", () => {
     expect(
       beadPickParentId({ dependencies: [{ depends_on_id: "neo-parent", type: "blocks" }] })
     ).toBe("");
+  });
+
+  it("reads parallel, agent, and worktree hints from direct fields or labels", () => {
+    expect(beadPickParallelizable({ parallel: "yes" })).toBe(true);
+    expect(beadPickParallelizable({ labels: ["sequential", "parallel-ok"] })).toBe(false);
+    expect(beadPickAgent({ labels: ["agent:agent-a"] })).toBe("agent-a");
+    expect(beadPickWorktree({ tags: ["wt:../repo-agent-a"] })).toBe("../repo-agent-a");
   });
 
   it("extracts progress percentages from direct fields or notes", () => {

--- a/tests/beadsWebviewMetadata.test.ts
+++ b/tests/beadsWebviewMetadata.test.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const repoRoot = join(import.meta.dirname, "..");
+const beadsWebview = readFileSync(join(repoRoot, "src", "beadsWebview.ts"), "utf8");
+const beadsMain = readFileSync(join(repoRoot, "web", "beadsMain.ts"), "utf8");
+
+describe("beads webview presentation metadata", () => {
+  it("renders readable task summary and responsive task rows", () => {
+    expect(beadsWebview).toContain("workspaceSummary");
+    expect(beadsWebview).toContain("summaryPill");
+    expect(beadsWebview).toContain("@media (max-width:560px)");
+    expect(beadsWebview).toContain("grid-template-areas");
+  });
+
+  it("keeps subproject collapse explicit and double-click driven", () => {
+    expect(beadsWebview).toContain("data-child-count");
+    expect(beadsWebview).toContain("collapseToggle");
+    expect(beadsMain).toContain("rowHasCollapsedAncestor");
+    expect(beadsMain).toContain('row.addEventListener("dblclick"');
+    expect(beadsMain).toContain("toggleRowCollapse(row)");
+  });
+});

--- a/tests/beadsWebviewMetadata.test.ts
+++ b/tests/beadsWebviewMetadata.test.ts
@@ -18,7 +18,10 @@ describe("beads webview presentation metadata", () => {
   it("keeps subproject collapse explicit and double-click driven", () => {
     expect(beadsWebview).toContain("data-child-count");
     expect(beadsWebview).toContain("collapseToggle");
+    expect(beadsWebview).toContain("hierarchyGuideVertical");
     expect(beadsMain).toContain("rowHasCollapsedAncestor");
+    expect(beadsMain).toContain("clearSelectedRow");
+    expect(beadsMain).toContain("const clickDelayMs = isCollapsibleRow(row) ? 260 : 160");
     expect(beadsMain).toContain('row.addEventListener("dblclick"');
     expect(beadsMain).toContain("toggleRowCollapse(row)");
   });

--- a/tests/worktreeSyncGuard.test.ts
+++ b/tests/worktreeSyncGuard.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  parseRevListCounts,
+  parseWorktreePorcelain,
+  summarizeFindings
+} from "../scripts/worktree-sync-guard.mjs";
+
+describe("worktree sync guard helpers", () => {
+  it("parses git worktree porcelain output", () => {
+    expect(
+      parseWorktreePorcelain(`worktree /repo
+HEAD abc123
+branch refs/heads/main
+
+worktree /repo-agent-a
+HEAD def456
+branch refs/heads/feature/a
+
+`)
+    ).toEqual([
+      {
+        path: "/repo",
+        branch: "main",
+        head: "abc123",
+        bare: false,
+        detached: false
+      },
+      {
+        path: "/repo-agent-a",
+        branch: "feature/a",
+        head: "def456",
+        bare: false,
+        detached: false
+      }
+    ]);
+  });
+
+  it("parses ahead and behind counts", () => {
+    expect(parseRevListCounts("2\t3\n")).toEqual({ ahead: 2, behind: 3 });
+  });
+
+  it("summarizes errors as blocking", () => {
+    expect(
+      summarizeFindings([
+        { level: "warning", path: "/repo", message: "No upstream branch is configured." },
+        { level: "error", path: "/repo-agent-a", message: "HEAD does not contain origin/main." }
+      ])
+    ).toMatchObject({
+      ok: false,
+      failures: [{ path: "/repo-agent-a" }],
+      warnings: [{ path: "/repo" }]
+    });
+  });
+});

--- a/web/beadsMain.ts
+++ b/web/beadsMain.ts
@@ -25,6 +25,9 @@ interface BeadRowItem {
   createdAt: string;
   parentId: string;
   epicId: string;
+  parallelizable: boolean;
+  agent: string;
+  worktree: string;
 }
 
 const vscode = acquireVsCodeApi();
@@ -213,6 +216,9 @@ function renderDetailsMarkup(item: BeadRowItem) {
     item.status === "in_progress" && item.progress !== null ? `${String(item.progress)}%` : "-";
   const parent = item.parentId !== "" ? item.parentId : "-";
   const epic = item.epicId !== "" && item.epicId !== item.id ? item.epicId : "-";
+  const parallel = item.parallelizable ? "Yes" : "-";
+  const agent = item.agent !== "" ? item.agent : "-";
+  const worktree = item.worktree !== "" ? item.worktree : "-";
 
   return (
     `<div class="details"><h3>${escapeHtml(item.id)} - ${escapeHtml(item.title)}</h3><div class="detailsGrid">` +
@@ -223,6 +229,9 @@ function renderDetailsMarkup(item: BeadRowItem) {
     `<div class="key">Progress</div><div>${escapeHtml(progress)}</div>` +
     `<div class="key">Priority</div><div>${escapeHtml(item.priority || "-")}</div>` +
     `<div class="key">Assignee</div><div>${escapeHtml(item.assignee || "-")}</div>` +
+    `<div class="key">Parallel</div><div>${escapeHtml(parallel)}</div>` +
+    `<div class="key">Agent</div><div>${escapeHtml(agent)}</div>` +
+    `<div class="key">Worktree</div><div>${escapeHtml(worktree)}</div>` +
     `<div class="key">Labels</div><div>${escapeHtml(item.labels || "-")}</div>` +
     `<div class="key">Created</div><div>${escapeHtml(item.createdAt || "-")}</div>` +
     `<div class="key">Updated</div><div>${escapeHtml(item.updatedAt || "-")}</div>` +

--- a/web/beadsMain.ts
+++ b/web/beadsMain.ts
@@ -271,6 +271,12 @@ function removeExpandedDetails() {
   expandedDetailsRow = null;
 }
 
+function clearSelectedRow() {
+  selectedRow?.classList.remove("selected");
+  selectedRow = null;
+  removeExpandedDetails();
+}
+
 function expandDetailsRow(row: BeadRow, item: BeadRowItem) {
   removeExpandedDetails();
   const detailsRow = document.createElement("tr");
@@ -340,9 +346,7 @@ function refreshRowVisibility() {
     }
   }
   if (selectedRow !== null && selectedRow.style.display === "none") {
-    selectedRow.classList.remove("selected");
-    selectedRow = null;
-    removeExpandedDetails();
+    clearSelectedRow();
   }
   if (contextMenuRow !== null && contextMenuRow.style.display === "none") {
     closeContextMenu();
@@ -514,8 +518,8 @@ function renderHierarchyOverlays() {
       const rowRect = row.getBoundingClientRect();
       const cellLeft = titleRect.left - wrapRect.left;
       const xBase = cellLeft + paddingBase;
-      const topY = rowRect.top - wrapRect.top + 2;
-      const bottomY = rowRect.bottom - wrapRect.top - 2;
+      const topY = rowRect.top - wrapRect.top;
+      const bottomY = rowRect.bottom - wrapRect.top;
       const midY = (topY + bottomY) / 2;
       const currentX = xBase + (depth - 0.5) * step;
       const endX = xBase + depth * step + 1;
@@ -531,8 +535,8 @@ function renderHierarchyOverlays() {
         }
         const x = xBase + (i + 0.5) * step;
         const segment = `M${x.toFixed(1)} ${topY.toFixed(1)} V ${bottomY.toFixed(1)}`;
-        shadowPaths += `<path class="hierarchyGuideShadow" d="${segment}" />`;
-        linePaths += `<path class="hierarchyGuideLine" d="${segment}" />`;
+        shadowPaths += `<path class="hierarchyGuideShadow hierarchyGuideVertical" d="${segment}" />`;
+        linePaths += `<path class="hierarchyGuideLine hierarchyGuideVertical" d="${segment}" />`;
       }
 
       const branchSegment = isLastSibling
@@ -645,9 +649,7 @@ for (const row of Array.from(document.querySelectorAll<BeadRow>("tbody tr.beadRo
     }
 
     if (selectedRow === row) {
-      row.classList.remove("selected");
-      selectedRow = null;
-      removeExpandedDetails();
+      clearSelectedRow();
       return;
     }
 
@@ -671,10 +673,11 @@ for (const row of Array.from(document.querySelectorAll<BeadRow>("tbody tr.beadRo
       return;
     }
     clearRowClickTimer();
+    const clickDelayMs = isCollapsibleRow(row) ? 260 : 160;
     rowClickTimer = window.setTimeout(() => {
       rowClickTimer = null;
       selectRow(event);
-    }, 160);
+    }, clickDelayMs);
   });
   row.addEventListener("dblclick", (event) => {
     if (event.target instanceof Element && event.target.closest("button")) {
@@ -682,9 +685,13 @@ for (const row of Array.from(document.querySelectorAll<BeadRow>("tbody tr.beadRo
     }
     clearRowClickTimer();
     event.preventDefault();
-    if (!toggleRowCollapse(row)) {
-      selectRow(event);
+    if (toggleRowCollapse(row)) {
+      if (selectedRow === row) {
+        clearSelectedRow();
+      }
+      return;
     }
+    selectRow(event);
   });
 }
 

--- a/web/beadsMain.ts
+++ b/web/beadsMain.ts
@@ -54,6 +54,8 @@ let expandedDetailsRow: HTMLTableRowElement | null = null;
 let contextMenuRow: BeadRow | null = null;
 let contextMenuWorkspacePath = "";
 let sortState: { key: SortKey; desc: boolean } = { key: "updated", desc: true };
+let rowClickTimer: number | null = null;
+const collapsedIds = new Set<string>();
 
 const chips = queryElement<HTMLDivElement>("#chips");
 const preset = queryElement<HTMLSelectElement>("#preset");
@@ -219,9 +221,20 @@ function renderDetailsMarkup(item: BeadRowItem) {
   const parallel = item.parallelizable ? "Yes" : "-";
   const agent = item.agent !== "" ? item.agent : "-";
   const worktree = item.worktree !== "" ? item.worktree : "-";
+  const executionPills = [
+    item.status !== "" ? `<span class="detailPill">Status ${escapeHtml(item.status)}</span>` : "",
+    item.priority !== ""
+      ? `<span class="detailPill">Priority ${escapeHtml(item.priority)}</span>`
+      : "",
+    item.parallelizable ? '<span class="detailPill">Parallel OK</span>' : "",
+    item.agent !== "" ? `<span class="detailPill">Agent ${escapeHtml(item.agent)}</span>` : "",
+    item.worktree !== "" ? `<span class="detailPill">WT ${escapeHtml(item.worktree)}</span>` : ""
+  ]
+    .filter((pill) => pill !== "")
+    .join("");
 
   return (
-    `<div class="details"><h3>${escapeHtml(item.id)} - ${escapeHtml(item.title)}</h3><div class="detailsGrid">` +
+    `<div class="details"><div class="detailsHeader"><div class="detailsId">${escapeHtml(item.id)}</div><div class="detailsTitle">${escapeHtml(item.title)}</div>${executionPills === "" ? "" : `<div class="detailsPills">${executionPills}</div>`}</div><div class="detailsGrid">` +
     `<div class="key">Type</div><div>${escapeHtml(item.type || "-")}</div>` +
     `<div class="key">Parent</div><div>${escapeHtml(parent)}</div>` +
     `<div class="key">Epic</div><div>${escapeHtml(epic)}</div>` +
@@ -275,12 +288,52 @@ function getVisibleBeadRows(scope: ParentNode = document) {
   return Array.from(scope.querySelectorAll<BeadRow>("tbody .beadRow"));
 }
 
-function applyFilters() {
+function getRowsById(rows: BeadRow[]) {
+  const rowsById = new Map<string, BeadRow>();
+  for (const row of rows) {
+    const id = row.dataset.id || "";
+    if (id !== "") {
+      rowsById.set(id, row);
+    }
+  }
+  return rowsById;
+}
+
+function rowHasCollapsedAncestor(row: BeadRow, rowsById: Map<string, BeadRow>) {
+  const visited = new Set<string>();
+  let parentId = row.dataset.parentId || "";
+
+  while (parentId !== "") {
+    if (visited.has(parentId)) {
+      return false;
+    }
+    visited.add(parentId);
+    if (collapsedIds.has(parentId)) {
+      return true;
+    }
+
+    const parentRow = rowsById.get(parentId);
+    if (parentRow === undefined) {
+      return false;
+    }
+    parentId = parentRow.dataset.parentId || "";
+  }
+
+  return false;
+}
+
+function refreshRowVisibility() {
   const rows = getVisibleBeadRows();
+  const rowsById = getRowsById(rows);
   let visibleCount = 0;
+  let matchingCount = 0;
   for (const row of rows) {
     const status = (row.dataset.status || "") as StatusFilter;
-    const visible = activeFilters.has(status);
+    const filterVisible = activeFilters.has(status);
+    if (filterVisible) {
+      matchingCount += 1;
+    }
+    const visible = filterVisible && !rowHasCollapsedAncestor(row, rowsById);
     row.style.display = visible ? "" : "none";
     if (visible) {
       visibleCount += 1;
@@ -294,8 +347,53 @@ function applyFilters() {
   if (contextMenuRow !== null && contextMenuRow.style.display === "none") {
     closeContextMenu();
   }
-  stats.textContent = `${visibleCount} / ${rows.length} beads shown`;
+  stats.textContent =
+    matchingCount === rows.length
+      ? `${visibleCount} / ${rows.length} beads shown`
+      : `${visibleCount} / ${matchingCount} matching beads shown`;
+  stats.title = `${rows.length} total beads`;
   renderHierarchyOverlays();
+}
+
+function applyFilters() {
+  refreshRowVisibility();
+}
+
+function isCollapsibleRow(row: BeadRow) {
+  return parseInt(row.dataset.childCount || "0", 10) > 0;
+}
+
+function updateCollapseButton(row: BeadRow) {
+  const id = row.dataset.id || "";
+  const button = row.querySelector<HTMLButtonElement>(".collapseToggle");
+  const collapsed = id !== "" && collapsedIds.has(id);
+  row.classList.toggle("collapsedParent", collapsed);
+  if (button !== null) {
+    button.setAttribute("aria-expanded", collapsed ? "false" : "true");
+  }
+}
+
+function toggleRowCollapse(row: BeadRow) {
+  const id = row.dataset.id || "";
+  if (id === "" || !isCollapsibleRow(row)) {
+    return false;
+  }
+
+  if (collapsedIds.has(id)) {
+    collapsedIds.delete(id);
+  } else {
+    collapsedIds.add(id);
+  }
+  updateCollapseButton(row);
+  refreshRowVisibility();
+  return true;
+}
+
+function clearRowClickTimer() {
+  if (rowClickTimer !== null) {
+    window.clearTimeout(rowClickTimer);
+    rowClickTimer = null;
+  }
 }
 
 function getSortValue(row: BeadRow, key: SortKey) {
@@ -373,7 +471,7 @@ function applySort() {
     icon.textContent = key === sortState.key ? (sortState.desc ? "▼" : "▲") : " ";
   }
 
-  renderHierarchyOverlays();
+  refreshRowVisibility();
 }
 
 function renderHierarchyOverlays() {
@@ -539,6 +637,7 @@ for (const button of Array.from(document.querySelectorAll<HTMLButtonElement>(".s
   });
 }
 for (const row of Array.from(document.querySelectorAll<BeadRow>("tbody tr.beadRow"))) {
+  const toggleButton = row.querySelector<HTMLButtonElement>(".collapseToggle");
   const selectRow = (event: MouseEvent) => {
     const target = event.target;
     if (target instanceof Element && target.closest("button")) {
@@ -563,8 +662,30 @@ for (const row of Array.from(document.querySelectorAll<BeadRow>("tbody tr.beadRo
     }
   };
 
-  row.addEventListener("click", selectRow);
-  row.addEventListener("dblclick", selectRow);
+  toggleButton?.addEventListener("click", (event) => {
+    event.stopPropagation();
+    toggleRowCollapse(row);
+  });
+  row.addEventListener("click", (event) => {
+    if (event.target instanceof Element && event.target.closest("button")) {
+      return;
+    }
+    clearRowClickTimer();
+    rowClickTimer = window.setTimeout(() => {
+      rowClickTimer = null;
+      selectRow(event);
+    }, 160);
+  });
+  row.addEventListener("dblclick", (event) => {
+    if (event.target instanceof Element && event.target.closest("button")) {
+      return;
+    }
+    clearRowClickTimer();
+    event.preventDefault();
+    if (!toggleRowCollapse(row)) {
+      selectRow(event);
+    }
+  });
 }
 
 renderFilterChips();


### PR DESCRIPTION
## Summary

- Add Beads view support for visual multi-agent task hints, stale worktree merge guards, and a clearer task screen.

## Changes

- Parse optional `parallelizable`, `agent`, and `worktree` metadata from issue fields or labels.
- Preserve metadata from `.beads/issues.jsonl` when CLI rows omit it.
- Show Parallel, Agent, and WT badges in Beads rows and full values in details.
- Add workspace summary pills, polished row styling, responsive compact rows, and clearer inline details.
- Smooth hierarchy guide lines so they do not appear broken between rows.
- Make epic/subproject rows collapsible via caret or double-click, and prevent double-click from leaving a stale details row open.
- Add `scripts/worktree-sync-guard.mjs` to check that PR or agent worktrees contain the latest base ref.
- Add a PR CI job that checks the PR head against `origin/${{ github.base_ref }}` before merge.
- Document supported hint conventions and the local worktree sync guard command in the README.
- Add regression coverage for metadata parsing, merge behavior, workflow metadata, webview presentation metadata, and guard helpers.

## Testing

- `oxfmt --check`
- `oxlint`
- `tsc -p ./src --noEmit`
- `tsc -p ./web --noEmit`
- `vitest run`
- `esbuild --bundle web/main.ts --outfile=out/web.min.js --minify --target=es6 --format=iife`
- `esbuild --bundle web/beadsMain.ts --outfile=out/beadsWebview.min.js --minify --target=es6 --format=iife`
- `node scripts/worktree-sync-guard.mjs --base origin/main`
- Browser preview on localhost for default and 430px-wide layouts was run before the final line-smoothing follow-up; the follow-up was verified with source, type, test, and bundle checks. A later in-app Browser recheck was blocked by URL policy.

## Notes

- Multi-agent hints are advisory visualization metadata; Beads ready and blocking semantics are unchanged.
- The new CI guard prevents stale PR heads from passing, but local `--all` checks are still useful before coordinating multiple agent worktrees.
- `bd sync` could not be run locally because the installed `bd` does not expose a `sync` command.