### PR TITLE
chore: release v0.1.33

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,24 @@
 
 ## [Unreleased]
 
+## [0.1.33] - 2026-06-13
+
+### Added
+
+- Show optional parallel, agent, and worktree hints directly in Beads task rows and details.
+- Add a worktree sync guard for checking stale multi-agent PR or agent worktrees before merge.
+
 ### Changed
 
+- Polish the Beads task screen with workspace summary pills, clearer row styling, responsive compact rows, and richer inline details.
 - Move the daily automation order so prerelease packaging runs before safe-update merging and backlog reporting
 - Make workflow-dispatched CI skip cross-platform smoke unless explicitly requested, so daily automation PR checks stay lightweight
 - Cut recurring GitHub Actions cost by making cross-platform smoke manual-only, moving CodeQL to a weekly cadence, and skipping daily prerelease packaging when nothing changed since the latest stable tag
 
 ### Fixed
 
+- Make EPIC double-click toggle subprojects instead of opening a stale details row.
+- Smooth Beads hierarchy guide lines so parent-child guides do not appear broken between rows.
 - Format the generated changelog before the daily changelog PR is committed, preventing the daily CI dispatch from failing on `CHANGELOG.md`
 - Publish the daily prerelease VSIX directly to Open VSX and VS Marketplace, and keep the stable `publish` workflow from re-running on `daily-*` tags
 
@@ -240,7 +250,8 @@
 
 Initial release
 
-[Unreleased]: https://github.com/ToppyMicroServices/beads-git-graph/compare/v0.1.32...HEAD
+[Unreleased]: https://github.com/ToppyMicroServices/beads-git-graph/compare/v0.1.33...HEAD
+[0.1.33]: https://github.com/ToppyMicroServices/beads-git-graph/compare/v0.1.32...v0.1.33
 [0.1.32]: https://github.com/ToppyMicroServices/beads-git-graph/compare/v0.1.31...v0.1.32
 [0.1.31]: https://github.com/ToppyMicroServices/beads-git-graph/compare/v0.1.30...v0.1.31
 [0.1.30]: https://github.com/ToppyMicroServices/beads-git-graph/compare/v0.1.29...v0.1.30

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Beads Git Graph
 
 [![MIT License](https://img.shields.io/badge/license-MIT-2ea44f?style=flat-square)](./LICENSE)
-[![Version 0.1.32](https://img.shields.io/badge/version-0.1.32-0366d6?style=flat-square)](./CHANGELOG.md)
+[![Version 0.1.33](https://img.shields.io/badge/version-0.1.33-0366d6?style=flat-square)](./CHANGELOG.md)
 
 Git graph and Beads issue tools in one VS Code extension.
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "beads-git-graph",
   "displayName": "Beads Git Graph",
-  "version": "0.1.32",
+  "version": "0.1.33",
   "description": "Git graph and Beads issue tools for VS Code.",
   "categories": [
     "Other",


### PR DESCRIPTION
## Summary

- Prepare the stable v0.1.33 Marketplace release.

## Changes

- Bump the extension version to 0.1.33.
- Update the README version badge.
- Move the current unreleased notes into the 0.1.33 changelog section.

## Testing

- `oxfmt --check CHANGELOG.md README.md package.json`
- `oxlint`
- `tsc -p ./src --noEmit`
- `tsc -p ./web --noEmit`
- `vitest run`
- `esbuild --bundle web/main.ts --outfile=out/web.min.js --minify --target=es6 --format=iife`
- `esbuild --bundle web/beadsMain.ts --outfile=out/beadsWebview.min.js --minify --target=es6 --format=iife`
- `pnpm audit --audit-level low`
- `pnpm run package`
- `node scripts/worktree-sync-guard.mjs --base origin/main`

## Notes

- GitHub code scanning, Dependabot, and secret scanning open-alert queries returned no open alerts.
- Full local `oxfmt --check` is currently blocked by untracked local `.beads` generated files from the merge hook/import dry-run, not by tracked release files.
- Local `bd sync` cannot be run because the installed `bd` does not expose a `sync` command.