### PR TITLE
fix: show parallel-ready bead tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Show ready, unblocked Beads tasks as parallel-ready candidates even when no explicit parallel metadata is set.
+
 ## [0.1.33] - 2026-06-13
 
 ### Added

--- a/src/beadsData.ts
+++ b/src/beadsData.ts
@@ -14,6 +14,8 @@ export interface BeadItem {
   createdAt: string;
   parentId: string;
   parallelizable: boolean;
+  parallelizableSource: "explicit" | "ready" | "";
+  parallelizableSuppressed: boolean;
   agent: string;
   worktree: string;
 }
@@ -124,6 +126,10 @@ function beadPickStringFromTokens(record: Record<string, unknown>, prefixes: str
 }
 
 export function beadPickParallelizable(record: Record<string, unknown>) {
+  return beadPickParallelizablePreference(record) === "yes";
+}
+
+export function beadPickParallelizablePreference(record: Record<string, unknown>) {
   const directKeys = [
     "parallelizable",
     "parallel",
@@ -138,26 +144,28 @@ export function beadPickParallelizable(record: Record<string, unknown>) {
   for (const key of directKeys) {
     const value = record[key];
     if (typeof value === "boolean") {
-      return value;
+      return value ? "yes" : "no";
     }
     if (typeof value === "string") {
       const normalized = normalizeToken(value);
       if (["true", "yes", "y", "1", "parallel", "parallel-ok"].includes(normalized)) {
-        return true;
+        return "yes";
       }
       if (["false", "no", "n", "0", "serial", "sequential"].includes(normalized)) {
-        return false;
+        return "no";
       }
     }
   }
 
   const labels = beadPickStringTokens(record, ["labels", "tags"]).map(normalizeToken);
   if (labels.some((label) => ["serial", "sequential", "no-parallel"].includes(label))) {
-    return false;
+    return "no";
   }
   return labels.some((label) =>
     ["parallel", "parallel-ok", "parallelizable", "multi-agent", "multiagent"].includes(label)
-  );
+  )
+    ? "yes"
+    : "";
 }
 
 export function beadPickAgent(record: Record<string, unknown>) {
@@ -266,6 +274,7 @@ export function toBeadItem(item: unknown): BeadItem | null {
   const record = item as Record<string, unknown>;
   const id = beadPickString(record, ["id", "key", "slug", "issue", "name"]);
   const title = beadPickString(record, ["title", "summary", "name", "description"]);
+  const parallelizablePreference = beadPickParallelizablePreference(record);
 
   if (id === "" || title === "") {
     return null;
@@ -285,7 +294,9 @@ export function toBeadItem(item: unknown): BeadItem | null {
     createdAt: beadPickString(record, ["created_at", "createdAt", "created"], "-"),
     updatedAt: beadPickString(record, ["updated_at", "updatedAt", "updated", "modified_at"], "-"),
     parentId: beadPickParentId(record),
-    parallelizable: beadPickParallelizable(record),
+    parallelizable: parallelizablePreference === "yes",
+    parallelizableSource: parallelizablePreference === "yes" ? "explicit" : "",
+    parallelizableSuppressed: parallelizablePreference === "no",
     agent: beadPickAgent(record),
     worktree: beadPickWorktree(record),
     commitHash: beadPickString(record, ["commitHash", "commit_hash", "commit"], "")
@@ -407,11 +418,21 @@ export function mergeBeadItems(primaryItems: BeadItem[], fallbackItems: BeadItem
       return item;
     }
 
+    const parallelizable = item.parallelizable || fallback.parallelizable;
+    const parallelizableSource = item.parallelizable
+      ? item.parallelizableSource
+      : fallback.parallelizable
+        ? fallback.parallelizableSource
+        : "";
+
     return {
       ...fallback,
       ...item,
       parentId: item.parentId.trim() !== "" ? item.parentId : fallback.parentId,
-      parallelizable: item.parallelizable || fallback.parallelizable,
+      parallelizable,
+      parallelizableSource,
+      parallelizableSuppressed:
+        !parallelizable && (item.parallelizableSuppressed || fallback.parallelizableSuppressed),
       agent: item.agent.trim() !== "" ? item.agent : fallback.agent,
       worktree: item.worktree.trim() !== "" ? item.worktree : fallback.worktree
     };
@@ -425,6 +446,39 @@ export function mergeBeadItems(primaryItems: BeadItem[], fallbackItems: BeadItem
   }
 
   return merged;
+}
+
+export function inferReadyParallelizableItems(
+  items: BeadItem[],
+  readyItemIds: ReadonlySet<string>
+) {
+  const eligibleReadyIds = new Set(
+    items
+      .filter((item) => {
+        if (item.parallelizable || item.parallelizableSuppressed) {
+          return false;
+        }
+        if (!readyItemIds.has(item.id)) {
+          return false;
+        }
+        if (normalizeBeadType(item.type) === "epic") {
+          return false;
+        }
+        const status = normalizeBeadStatus(item.status);
+        return status === "open" || status === "in_progress";
+      })
+      .map((item) => item.id)
+  );
+
+  if (eligibleReadyIds.size < 2) {
+    return items;
+  }
+
+  return items.map((item) =>
+    eligibleReadyIds.has(item.id)
+      ? { ...item, parallelizable: true, parallelizableSource: "ready" as const }
+      : item
+  );
 }
 
 export function diffBeadItems(
@@ -447,6 +501,7 @@ export function diffBeadItems(
     "createdAt",
     "parentId",
     "parallelizable",
+    "parallelizableSuppressed",
     "agent",
     "worktree",
     "commitHash"

--- a/src/beadsView.ts
+++ b/src/beadsView.ts
@@ -8,6 +8,7 @@ import {
   beadsAsArray,
   diffBeadItems,
   extractBeadItems,
+  inferReadyParallelizableItems,
   mergeBeadItems,
   toBeadItem
 } from "./beadsData";
@@ -702,6 +703,8 @@ export class BeadsViewProvider implements vscode.WebviewViewProvider, vscode.Dis
     const stdout = await this.runBdCommand(["list", "--json", "--limit", "0", "--all"], cwd);
     const parsed = stdout.trim() === "" ? [] : JSON.parse(stdout);
     const cliItems = extractBeadItems(parsed);
+    const warnings: BeadWarning[] = [];
+    const readyItemIds = await this.loadReadyItemIds(cwd, warnings);
     const itemsNeedingParentLookup = new Set<string>(
       beadsAsArray(parsed)
         .map((item) => {
@@ -722,7 +725,6 @@ export class BeadsViewProvider implements vscode.WebviewViewProvider, vscode.Dis
         })
         .filter((id): id is string => id !== null)
     );
-    const warnings: BeadWarning[] = [];
 
     try {
       const issueFileUri = vscode.Uri.file(path.join(cwd, ".beads", "issues.jsonl"));
@@ -778,17 +780,41 @@ export class BeadsViewProvider implements vscode.WebviewViewProvider, vscode.Dis
         });
       }
 
-      return { items: mergedItems, warnings };
+      return { items: inferReadyParallelizableItems(mergedItems, readyItemIds), warnings };
     } catch {
       const missingParentIds = cliItems
         .filter((item) => item.parentId.trim() === "" && itemsNeedingParentLookup.has(item.id))
         .map((item) => item.id);
       if (missingParentIds.length === 0) {
-        return { items: cliItems, warnings };
+        return { items: inferReadyParallelizableItems(cliItems, readyItemIds), warnings };
       }
 
       const parentLookupItems = await this.loadBdShowItems(missingParentIds, cwd);
-      return { items: mergeBeadItems(cliItems, parentLookupItems), warnings };
+      return {
+        items: inferReadyParallelizableItems(
+          mergeBeadItems(cliItems, parentLookupItems),
+          readyItemIds
+        ),
+        warnings
+      };
+    }
+  }
+
+  private async loadReadyItemIds(cwd: string, warnings: BeadWarning[]) {
+    try {
+      const stdout = await this.runBdCommand(["ready", "--json"], cwd);
+      const parsed = stdout.trim() === "" ? [] : JSON.parse(stdout);
+      return new Set(extractBeadItems(parsed).map((item) => item.id));
+    } catch (error) {
+      warnings.push({
+        source: path.join(cwd, ".beads"),
+        workspacePath: cwd,
+        message:
+          error instanceof Error
+            ? `Unable to infer parallel-ready tasks from bd ready: ${error.message}`
+            : "Unable to infer parallel-ready tasks from bd ready."
+      });
+      return new Set<string>();
     }
   }
 

--- a/src/beadsWebview.ts
+++ b/src/beadsWebview.ts
@@ -116,7 +116,7 @@ export function renderBeadsWebviewHtml(
                     .pop() ?? item.worktree);
             const executionBadges = [
               item.parallelizable
-                ? '<span class="executionBadge parallelBadge">Parallel</span>'
+                ? `<span class="executionBadge parallelBadge" title="${escapeHtml(item.parallelizableSource === "ready" ? "Ready and unblocked; can run alongside other ready tasks." : "Marked as parallelizable.")}">${escapeHtml(item.parallelizableSource === "ready" ? "Parallel ready" : "Parallel OK")}</span>`
                 : "",
               item.agent === ""
                 ? ""
@@ -254,7 +254,7 @@ th:nth-child(1){width:52px;}th:nth-child(3){width:78px;}th:nth-child(4){width:56
 .beadTitle{font-size:13px;font-weight:650;line-height:1.25;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}
 .beadMeta{display:flex;align-items:center;gap:4px;flex-wrap:wrap;margin-top:4px;}
 .executionBadge{display:inline-flex;align-items:center;max-width:100%;padding:1px 6px;border-radius:6px;border:1px solid rgba(128,128,128,.42);font-size:10px;font-weight:650;line-height:15px;color:var(--vscode-descriptionForeground);background:rgba(128,128,128,.1);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}
-.parallelBadge{border-color:rgba(34,197,94,.55);color:var(--vscode-testing-iconPassed, #22c55e);background:rgba(34,197,94,.12);}
+.parallelBadge{border-color:rgba(34,197,94,.65);color:var(--vscode-testing-iconPassed, #22c55e);background:rgba(34,197,94,.16);}
 .agentBadge{border-color:rgba(59,130,246,.55);color:var(--vscode-textLink-foreground, #3b82f6);background:rgba(59,130,246,.12);}
 .worktreeBadge{border-color:rgba(234,179,8,.55);color:var(--vscode-charts-yellow, #d97706);background:rgba(234,179,8,.12);}
 .statusCell{display:flex;align-items:center;gap:6px;flex-wrap:wrap;}

--- a/tests/beadsData.test.ts
+++ b/tests/beadsData.test.ts
@@ -12,6 +12,7 @@ import {
   buildBeadHierarchy,
   diffBeadItems,
   extractBeadItems,
+  inferReadyParallelizableItems,
   mergeBeadItems,
   normalizeBeadPriority,
   normalizeBeadStatus,
@@ -71,6 +72,8 @@ describe("toBeadItem", () => {
       updatedAt: "2026-03-07T01:00:00Z",
       parentId: "",
       parallelizable: false,
+      parallelizableSource: "",
+      parallelizableSuppressed: false,
       agent: "",
       worktree: "",
       commitHash: "abcdef1234567"
@@ -89,6 +92,8 @@ describe("toBeadItem", () => {
       })
     ).toMatchObject({
       parallelizable: true,
+      parallelizableSource: "explicit",
+      parallelizableSuppressed: false,
       agent: "agent-a",
       worktree: "../beads-git-graph-agent-a"
     });
@@ -101,6 +106,8 @@ describe("toBeadItem", () => {
       })
     ).toMatchObject({
       parallelizable: true,
+      parallelizableSource: "explicit",
+      parallelizableSuppressed: false,
       agent: "agent-b",
       worktree: "../beads-git-graph-agent-b"
     });
@@ -372,8 +379,62 @@ describe("buildBeadHierarchy", () => {
 
     expect(mergeBeadItems(cliItems, jsonlItems)[0]).toMatchObject({
       parallelizable: true,
+      parallelizableSource: "explicit",
       agent: "agent-a",
       worktree: "../beads-git-graph-agent-a"
+    });
+  });
+
+  it("marks multiple ready unblocked tasks as parallel candidates", () => {
+    const items = extractBeadItems([
+      {
+        id: "neo-ready-a",
+        title: "Ready A",
+        issue_type: "task",
+        status: "open"
+      },
+      {
+        id: "neo-ready-b",
+        title: "Ready B",
+        issue_type: "task",
+        status: "open"
+      },
+      {
+        id: "neo-blocked",
+        title: "Blocked",
+        issue_type: "task",
+        status: "blocked"
+      },
+      {
+        id: "neo-serial",
+        title: "Serial",
+        issue_type: "task",
+        status: "open",
+        labels: ["no-parallel"]
+      }
+    ]);
+
+    const inferred = inferReadyParallelizableItems(
+      items,
+      new Set(["neo-ready-a", "neo-ready-b", "neo-serial"])
+    );
+    const byId = new Map(inferred.map((item) => [item.id, item]));
+
+    expect(byId.get("neo-ready-a")).toMatchObject({
+      parallelizable: true,
+      parallelizableSource: "ready"
+    });
+    expect(byId.get("neo-ready-b")).toMatchObject({
+      parallelizable: true,
+      parallelizableSource: "ready"
+    });
+    expect(byId.get("neo-blocked")).toMatchObject({
+      parallelizable: false,
+      parallelizableSource: ""
+    });
+    expect(byId.get("neo-serial")).toMatchObject({
+      parallelizable: false,
+      parallelizableSuppressed: true
     });
   });
 });

--- a/tests/beadsWebviewMetadata.test.ts
+++ b/tests/beadsWebviewMetadata.test.ts
@@ -25,4 +25,11 @@ describe("beads webview presentation metadata", () => {
     expect(beadsMain).toContain('row.addEventListener("dblclick"');
     expect(beadsMain).toContain("toggleRowCollapse(row)");
   });
+
+  it("shows inferred parallel-ready task metadata", () => {
+    expect(beadsWebview).toContain("Parallel ready");
+    expect(beadsWebview).toContain("parallelizableSource");
+    expect(beadsMain).toContain("Yes (ready)");
+    expect(beadsMain).toContain("Parallel ready");
+  });
 });

--- a/web/beadsMain.ts
+++ b/web/beadsMain.ts
@@ -26,6 +26,7 @@ interface BeadRowItem {
   parentId: string;
   epicId: string;
   parallelizable: boolean;
+  parallelizableSource: "explicit" | "ready" | "";
   agent: string;
   worktree: string;
 }
@@ -218,7 +219,12 @@ function renderDetailsMarkup(item: BeadRowItem) {
     item.status === "in_progress" && item.progress !== null ? `${String(item.progress)}%` : "-";
   const parent = item.parentId !== "" ? item.parentId : "-";
   const epic = item.epicId !== "" && item.epicId !== item.id ? item.epicId : "-";
-  const parallel = item.parallelizable ? "Yes" : "-";
+  const parallel =
+    item.parallelizableSource === "ready"
+      ? "Yes (ready)"
+      : item.parallelizable
+        ? "Yes (explicit)"
+        : "-";
   const agent = item.agent !== "" ? item.agent : "-";
   const worktree = item.worktree !== "" ? item.worktree : "-";
   const executionPills = [
@@ -226,7 +232,9 @@ function renderDetailsMarkup(item: BeadRowItem) {
     item.priority !== ""
       ? `<span class="detailPill">Priority ${escapeHtml(item.priority)}</span>`
       : "",
-    item.parallelizable ? '<span class="detailPill">Parallel OK</span>' : "",
+    item.parallelizable
+      ? `<span class="detailPill">${escapeHtml(item.parallelizableSource === "ready" ? "Parallel ready" : "Parallel OK")}</span>`
+      : "",
     item.agent !== "" ? `<span class="detailPill">Agent ${escapeHtml(item.agent)}</span>` : "",
     item.worktree !== "" ? `<span class="detailPill">WT ${escapeHtml(item.worktree)}</span>` : ""
   ]


### PR DESCRIPTION
## Summary

- Show Beads tasks that are ready and unblocked as parallel-ready candidates even when no explicit parallel metadata exists.

## Changes

- Infer parallel-ready task badges from bd ready JSON results.
- Keep explicit parallelizable and no-parallel metadata respected.
- Distinguish explicit Parallel OK from inferred Parallel ready in rows and details.
- Add regression tests for ready-derived parallel candidates and presentation metadata.
- Document the fix in the unreleased changelog.

## Testing

- pnpm exec oxfmt --check CHANGELOG.md src/beadsData.ts src/beadsView.ts src/beadsWebview.ts web/beadsMain.ts tests/beadsData.test.ts tests/beadsWebviewMetadata.test.ts
- git diff --check
- pnpm test -- beadsData beadsWebviewMetadata
- pnpm run typecheck
- pnpm run lint
- pnpm run compile-web

## Notes

- Full pnpm run format still checks existing untracked .beads runtime/generated files in this local checkout; the changed files pass targeted format checking.