### PR TITLE
chore: release v0.1.34

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.1.34] - 2026-06-14
+
 ### Fixed
 
 - Show ready, unblocked Beads tasks as parallel-ready candidates even when no explicit parallel metadata is set.
@@ -254,7 +256,8 @@
 
 Initial release
 
-[Unreleased]: https://github.com/ToppyMicroServices/beads-git-graph/compare/v0.1.33...HEAD
+[Unreleased]: https://github.com/ToppyMicroServices/beads-git-graph/compare/v0.1.34...HEAD
+[0.1.34]: https://github.com/ToppyMicroServices/beads-git-graph/compare/v0.1.33...v0.1.34
 [0.1.33]: https://github.com/ToppyMicroServices/beads-git-graph/compare/v0.1.32...v0.1.33
 [0.1.32]: https://github.com/ToppyMicroServices/beads-git-graph/compare/v0.1.31...v0.1.32
 [0.1.31]: https://github.com/ToppyMicroServices/beads-git-graph/compare/v0.1.30...v0.1.31

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Beads Git Graph
 
 [![MIT License](https://img.shields.io/badge/license-MIT-2ea44f?style=flat-square)](./LICENSE)
-[![Version 0.1.33](https://img.shields.io/badge/version-0.1.33-0366d6?style=flat-square)](./CHANGELOG.md)
+[![Version 0.1.34](https://img.shields.io/badge/version-0.1.34-0366d6?style=flat-square)](./CHANGELOG.md)
 
 Git graph and Beads issue tools in one VS Code extension.
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "beads-git-graph",
   "displayName": "Beads Git Graph",
-  "version": "0.1.33",
+  "version": "0.1.34",
   "description": "Git graph and Beads issue tools for VS Code.",
   "categories": [
     "Other",


### PR DESCRIPTION
## Summary

- Prepare stable v0.1.34 for the parallel-ready Beads task fix.

## Changes

- Bump package version to 0.1.34.
- Update the README version badge.
- Move the parallel-ready task fix from Unreleased into the 0.1.34 changelog section.

## Testing

- pnpm exec oxfmt --check README.md CHANGELOG.md package.json
- git diff --check

## Notes

- This release is intended to publish the PR 137 fix to VS Marketplace and Open VSX.