### PR TITLE
chore: modernize TypeScript and VS Code baseline

### DIFF
--- a/.beads/interactions.jsonl
+++ b/.beads/interactions.jsonl
@@ -1,0 +1,2 @@
+{"id":"int-befac5f1a1a0bfd2171519d50f71383e","kind":"field_change","created_at":"2026-06-17T13:17:38.63017Z","actor":"thinksyncs","issue_id":"neo-git-graph-ahd","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
+{"id":"int-1d2d0b3810cabb3d5f405e32c955d41f","kind":"field_change","created_at":"2026-06-17T13:17:39.659118Z","actor":"thinksyncs","issue_id":"neo-git-graph-ccd","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^25.9.3",
-    "@types/vscode": "~1.110.0",
+    "@types/vscode": "~1.120.0",
     "dompurify": "^3.4.10",
     "esbuild": "^0.28.1",
     "eslint-plugin-simple-import-sort": "^13.0.0",
@@ -381,7 +381,7 @@
   ],
   "icon": "resources/icon.png",
   "engines": {
-    "vscode": "^1.110.0"
+    "vscode": "^1.120.0"
   },
   "packageManager": "pnpm@10.29.3"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^25.9.3
         version: 25.9.3
       '@types/vscode':
-        specifier: ~1.110.0
-        version: 1.110.0
+        specifier: ~1.120.0
+        version: 1.120.0
       dompurify:
         specifier: ^3.4.10
         version: 3.4.10
@@ -640,8 +640,8 @@ packages:
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
 
-  '@types/vscode@1.110.0':
-    resolution: {integrity: sha512-AGuxUEpU4F4mfuQjxPPaQVyuOMhs+VT/xRok1jiHVBubHK7lBRvCuOMZG0LKUwxncrPorJ5qq/uil3IdZBd5lA==}
+  '@types/vscode@1.120.0':
+    resolution: {integrity: sha512-feaT4Rst+FkTch5zz/ZbNCxoIvo55YU80Be2kiL7OJcod4+CUYf2lUBPdIJzozNnSEMq1VRTGrWEcCGFB3fBmA==}
 
   '@vitest/expect@4.1.8':
     resolution: {integrity: sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==}
@@ -1554,7 +1554,7 @@ snapshots:
   '@types/trusted-types@2.0.7':
     optional: true
 
-  '@types/vscode@1.110.0': {}
+  '@types/vscode@1.120.0': {}
 
   '@vitest/expect@4.1.8':
     dependencies:

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -1,10 +1,9 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "ignoreDeprecations": "6.0",
     "lib": ["es2020"],
-    "module": "commonjs",
-    "moduleResolution": "node",
+    "module": "Node16",
+    "moduleResolution": "node16",
     "outDir": "../out",
     "noFallthroughCasesInSwitch": true,
     "noImplicitAny": true,

--- a/web/main.ts
+++ b/web/main.ts
@@ -6,7 +6,7 @@ import {
 } from "../src/remotes";
 import { Dropdown } from "./dropdown";
 import { Graph } from "./graph";
-import createDOMPurify = require("dompurify");
+import createDOMPurify from "dompurify";
 import {
   abbrevCommit,
   addListenerToClass,

--- a/web/main.ts
+++ b/web/main.ts
@@ -1,3 +1,5 @@
+import createDOMPurify from "dompurify";
+
 import { classifyCommitSubject } from "../src/commitTypes";
 import {
   filterBranchesForRemote,
@@ -6,7 +8,6 @@ import {
 } from "../src/remotes";
 import { Dropdown } from "./dropdown";
 import { Graph } from "./graph";
-import createDOMPurify from "dompurify";
 import {
   abbrevCommit,
   addListenerToClass,

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -1,9 +1,8 @@
 {
   "compilerOptions": {
-    "ignoreDeprecations": "6.0",
     "lib": ["es2020", "dom"],
-    "module": "commonjs",
-    "moduleResolution": "node",
+    "module": "esnext",
+    "moduleResolution": "bundler",
     "noFallthroughCasesInSwitch": true,
     "noImplicitAny": true,
     "noUnusedLocals": true,


### PR DESCRIPTION
## Summary
- migrate src/web TypeScript configs away from deprecated moduleResolution settings
- switch the web DOMPurify import to ES module syntax so bundler resolution typechecks cleanly
- raise @types/vscode and engines.vscode to 1.120.0

## Validation
- pnpm exec tsc -p ./src --noEmit
- pnpm exec tsc -p ./web --noEmit
- pnpm test
- pnpm run compile
- pnpm exec oxfmt --check package.json src/tsconfig.json web/tsconfig.json web/main.ts

## Notes
- repo-wide format is currently tripped by local .beads generated JSON artifacts, so formatting was validated on the changed files only
- .beads/interactions.jsonl is intentionally included to record that neo-git-graph-ahd and neo-git-graph-ccd moved to in_progress with this PR