### PR TITLE
feat: add multi-agent bead automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ No telemetry. Privacy-first. Security-first.
 - Lets you switch between Git Graph and Beads from the toolbar
 - Lets you refresh, create, close, and sync Beads items inside VS Code
 - Shows optional parallel, AI model, SSOT/context, and worktree hints on Beads items
-- Shows a Beads critical path graph with dependency edges and Start AI actions
+- Shows a Beads critical path graph with dependency edges, Start AI, Start Parallel, and merge actions
 
 ## Use It
 
@@ -34,11 +34,15 @@ The Beads view surfaces optional execution hints from issue fields, metadata, or
 - `ssot: "AGENTS.md, .beads/issues.jsonl"` or label `ssot:AGENTS.md`
 - `worktree: "../repo-agent-a"` or label `worktree:../repo-agent-a`
 
-When you use **Start AI**, the extension asks for a model, automatically suggests SSOT/context from workspace files such as `AGENTS.md`, `.beads/issues.jsonl`, `README.md`, and `docs`, records that metadata, marks the bead in progress, then opens a GitHub Copilot Background Agent chat session with the bead prompt prefilled.
+When you use **Start AI**, the extension automatically picks the configured or default model, infers SSOT/context from workspace files such as `AGENTS.md`, `.beads/issues.jsonl`, `README.md`, and `docs`, creates or reuses a git worktree for the task, records model/SSOT/worktree metadata, marks the bead in progress, then opens a GitHub Copilot Background Agent chat session with the bead prompt prefilled.
+
+When multiple ready tasks can run in parallel, **Start Parallel** assigns and starts them in one action. Each task receives its own worktree so the Beads table and graph can show which worktree is expected to carry that agent's changes.
 
 These hints are visual metadata. Beads ready/blocking behavior still comes from issue status and dependencies.
 
-Before merging a multi-agent PR, make sure every agent worktree contains the latest base branch:
+For derived parallel merge tasks, **Merge PRs** checks the registered agent worktrees before asking GitHub CLI to auto-merge their branch PRs. It blocks if a worktree is not registered, does not contain `origin/main`, or has uncommitted changes.
+
+You can run the same guard manually:
 
 ```bash
 pnpm run worktree-sync:guard -- --base origin/main

--- a/src/beadsProtocol.ts
+++ b/src/beadsProtocol.ts
@@ -15,7 +15,42 @@ export type BeadsRequestMessage =
       model?: string;
       ssot?: string;
       worktree?: string;
+    }
+  | {
+      command: "startParallelBeads";
+      workspacePath: string;
+      items: BeadsExecutionTarget[];
+    }
+  | {
+      command: "mergeParallelPrs";
+      issueId: string;
+      workspacePath: string;
+      title?: string;
+      dependencies: BeadsExecutionTarget[];
     };
+
+export interface BeadsExecutionTarget {
+  issueId: string;
+  title?: string;
+  model?: string;
+  ssot?: string;
+  worktree?: string;
+}
+
+function isBeadsExecutionTarget(value: unknown): value is BeadsExecutionTarget {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+
+  const record = value as Record<string, unknown>;
+  return (
+    typeof record.issueId === "string" &&
+    (typeof record.title === "string" || typeof record.title === "undefined") &&
+    (typeof record.model === "string" || typeof record.model === "undefined") &&
+    (typeof record.ssot === "string" || typeof record.ssot === "undefined") &&
+    (typeof record.worktree === "string" || typeof record.worktree === "undefined")
+  );
+}
 
 export function isBeadsRequestMessage(message: unknown): message is BeadsRequestMessage {
   if (typeof message !== "object" || message === null) {
@@ -31,8 +66,22 @@ export function isBeadsRequestMessage(message: unknown): message is BeadsRequest
     case "syncBeads":
     case "createBead":
       return typeof record.workspacePath === "string";
+    case "startParallelBeads":
+      return (
+        typeof record.workspacePath === "string" &&
+        Array.isArray(record.items) &&
+        record.items.every(isBeadsExecutionTarget)
+      );
     case "openGitGraphForCommit":
       return typeof record.commitHash === "string";
+    case "mergeParallelPrs":
+      return (
+        typeof record.issueId === "string" &&
+        typeof record.workspacePath === "string" &&
+        (typeof record.title === "string" || typeof record.title === "undefined") &&
+        Array.isArray(record.dependencies) &&
+        record.dependencies.every(isBeadsExecutionTarget)
+      );
     case "closeBead":
     case "assignStartBead":
       return (

--- a/src/beadsView.ts
+++ b/src/beadsView.ts
@@ -14,7 +14,7 @@ import {
   mergeBeadItems,
   toBeadItem
 } from "./beadsData";
-import { isBeadsRequestMessage } from "./beadsProtocol";
+import { type BeadsExecutionTarget, isBeadsRequestMessage } from "./beadsProtocol";
 import { flushBeadsWorkspace, syncBeadsWorkspace } from "./beadsSync";
 import {
   type BeadGroup,
@@ -33,7 +33,6 @@ type CreateBeadType = "task" | "feature" | "bug" | "epic" | "chore";
 type CreateBeadStatus = "open" | "in_progress" | "blocked" | "closed";
 type CreateBeadPriority = "P0" | "P1" | "P2" | "P3" | "P4";
 const DEFAULT_ASSIGN_MODEL = "gpt-5-codex";
-const ASSIGN_MODEL_OPTIONS = [DEFAULT_ASSIGN_MODEL, "gpt-5", "codex"];
 const ASSIGN_CONTEXT_CANDIDATES = [
   "AGENTS.md",
   ".codex",
@@ -47,6 +46,12 @@ const COPILOT_ASSIGN_COMMAND_CANDIDATES = [
   "workbench.action.chat.openSessionWithPrompt.copilotcli",
   "workbench.action.chat.openSessionWithPrompt.copilot-cloud-agent"
 ];
+
+interface GitWorktreeInfo {
+  path: string;
+  branch: string;
+  head: string;
+}
 
 export class BeadsViewProvider implements vscode.WebviewViewProvider, vscode.Disposable {
   public static readonly viewType = "beads-git-graph.beadsView";
@@ -451,7 +456,7 @@ export class BeadsViewProvider implements vscode.WebviewViewProvider, vscode.Dis
       }
 
       try {
-        await this.promptAssignAndStartBead(
+        await this.autoAssignAndStartBead(
           workspacePath,
           issueId,
           message.title,
@@ -464,10 +469,64 @@ export class BeadsViewProvider implements vscode.WebviewViewProvider, vscode.Dis
           error instanceof Error ? error.message : "Unable to assign and start bead.";
         vscode.window.showErrorMessage(messageText);
       }
+      return;
+    }
+
+    if (
+      message.command === "startParallelBeads" &&
+      typeof message.workspacePath === "string" &&
+      Array.isArray(message.items)
+    ) {
+      const workspacePath = await this.resolveAuthorizedWorkspacePath(message.workspacePath.trim());
+      if (workspacePath === null) {
+        vscode.window.showWarningMessage(
+          "Refusing to start parallel beads outside an initialized workspace folder."
+        );
+        return;
+      }
+
+      try {
+        await this.startParallelBeads(workspacePath, message.items);
+      } catch (error) {
+        const messageText =
+          error instanceof Error ? error.message : "Unable to start parallel beads.";
+        vscode.window.showErrorMessage(messageText);
+      }
+      return;
+    }
+
+    if (
+      message.command === "mergeParallelPrs" &&
+      typeof message.issueId === "string" &&
+      typeof message.workspacePath === "string"
+    ) {
+      const issueId = message.issueId.trim();
+      const workspacePath = await this.resolveAuthorizedWorkspacePath(message.workspacePath.trim());
+      if (issueId === "" || workspacePath === null) {
+        if (workspacePath === null) {
+          vscode.window.showWarningMessage(
+            "Refusing to merge PRs outside an initialized workspace folder."
+          );
+        }
+        return;
+      }
+
+      try {
+        await this.mergeParallelPullRequests(
+          workspacePath,
+          issueId,
+          message.title,
+          message.dependencies
+        );
+      } catch (error) {
+        const messageText =
+          error instanceof Error ? error.message : "Unable to merge parallel PRs.";
+        vscode.window.showErrorMessage(messageText);
+      }
     }
   }
 
-  private async promptAssignAndStartBead(
+  private async autoAssignAndStartBead(
     workspacePath: string,
     issueId: string,
     title: string | undefined,
@@ -475,53 +534,164 @@ export class BeadsViewProvider implements vscode.WebviewViewProvider, vscode.Dis
     currentSsot: string | undefined,
     currentWorktree: string | undefined
   ) {
-    const model = await this.pickAssignModel(currentModel);
-    if (model === undefined) {
-      return;
-    }
+    const model = this.resolveAssignModel(currentModel);
+    const ssot = this.resolveAssignSsot(workspacePath, issueId, currentSsot);
+    const worktree = this.resolveAssignWorktree(workspacePath, issueId, currentWorktree);
 
-    const ssot = await this.confirmAssignContext(workspacePath, issueId, title, model, currentSsot);
-    if (ssot === undefined) {
-      return;
-    }
-
-    await this.runBdCommand(["assign", issueId, model], workspacePath);
-    await this.runBdCommand(
-      [
-        "update",
-        issueId,
-        "--status",
-        "in_progress",
-        "--set-metadata",
-        `agent=${model}`,
-        "--set-metadata",
-        `model=${model}`,
-        "--set-metadata",
-        `ssot=${ssot}`
-      ],
-      workspacePath
-    );
-    await flushBeadsWorkspace((args, cwd) => this.runBdCommand(args, cwd), workspacePath);
-    await this.refresh();
-
-    const openedChat = await this.openAssignAgentSession({
+    const openedChat = await this.assignAndStartBead({
       workspacePath,
       issueId,
       title,
       model,
       ssot,
-      worktree: currentWorktree
+      worktree
     });
+    await this.refresh();
 
     if (openedChat) {
       vscode.window.showInformationMessage(
-        `Started ${issueId} with ${model}. Opened Copilot agent session.`
+        `Started ${issueId} with ${model}. Opened Copilot agent session for ${path.basename(worktree)}.`
       );
       return;
     }
 
     vscode.window.showWarningMessage(
       `Started ${issueId} with ${model}, but could not open a Copilot agent session automatically.`
+    );
+  }
+
+  private async assignAndStartBead(values: {
+    workspacePath: string;
+    issueId: string;
+    title: string | undefined;
+    model: string;
+    ssot: string;
+    worktree: string;
+  }) {
+    const worktree = await this.ensureAgentWorktree(
+      values.workspacePath,
+      values.issueId,
+      values.worktree
+    );
+    const metadata = [
+      `agent=${values.model}`,
+      `model=${values.model}`,
+      `ssot=${values.ssot}`,
+      `worktree=${worktree}`
+    ];
+
+    await this.runBdCommand(["assign", values.issueId, values.model], values.workspacePath);
+    await this.runBdCommand(
+      [
+        "update",
+        values.issueId,
+        "--status",
+        "in_progress",
+        ...metadata.flatMap((entry) => ["--set-metadata", entry])
+      ],
+      values.workspacePath
+    );
+    await flushBeadsWorkspace((args, cwd) => this.runBdCommand(args, cwd), values.workspacePath);
+
+    return this.openAssignAgentSession({ ...values, worktree });
+  }
+
+  private async startParallelBeads(workspacePath: string, items: BeadsExecutionTarget[]) {
+    const candidates = items
+      .map((item) => ({
+        issueId: item.issueId.trim(),
+        title: item.title,
+        model: this.resolveAssignModel(item.model),
+        ssot: "",
+        worktree: ""
+      }))
+      .filter((item) => item.issueId !== "");
+
+    if (candidates.length === 0) {
+      vscode.window.showWarningMessage("No parallel beads were available to start.");
+      return;
+    }
+
+    const uniqueCandidates = [...new Map(candidates.map((item) => [item.issueId, item])).values()];
+    let openedCount = 0;
+    for (const candidate of uniqueCandidates) {
+      const source = items.find((item) => item.issueId.trim() === candidate.issueId);
+      candidate.ssot = this.resolveAssignSsot(workspacePath, candidate.issueId, source?.ssot);
+      candidate.worktree = this.resolveAssignWorktree(
+        workspacePath,
+        candidate.issueId,
+        source?.worktree
+      );
+      const opened = await this.assignAndStartBead({
+        workspacePath,
+        issueId: candidate.issueId,
+        title: candidate.title,
+        model: candidate.model,
+        ssot: candidate.ssot,
+        worktree: candidate.worktree
+      });
+      if (opened) {
+        openedCount += 1;
+      }
+    }
+
+    await this.refresh();
+    vscode.window.showInformationMessage(
+      `Started ${uniqueCandidates.length} parallel bead(s). Opened ${openedCount} Copilot session(s).`
+    );
+  }
+
+  private async mergeParallelPullRequests(
+    workspacePath: string,
+    issueId: string,
+    title: string | undefined,
+    dependencies: BeadsExecutionTarget[]
+  ) {
+    const worktrees = await this.resolveDependencyWorktrees(workspacePath, dependencies);
+    if (worktrees.length === 0) {
+      throw new Error("No dependency worktrees were found for this parallel merge task.");
+    }
+
+    const confirmation = await vscode.window.showWarningMessage(
+      `Auto-merge PRs for ${issueId}${title ? `: ${title}` : ""}?`,
+      {
+        modal: true,
+        detail:
+          "The extension will fetch origin, verify each agent worktree contains origin/main and has no uncommitted changes, then ask GitHub CLI to auto-merge the matching branch PRs."
+      },
+      "Merge PRs"
+    );
+    if (confirmation !== "Merge PRs") {
+      return;
+    }
+
+    await this.runGitCommand(["fetch", "origin"], workspacePath);
+    await this.assertWorktreesReadyForMerge(worktrees);
+
+    const mergedPrs: string[] = [];
+    for (const worktree of worktrees) {
+      if (worktree.branch.trim() === "") {
+        throw new Error(`Worktree ${worktree.path} is detached; cannot find a branch PR.`);
+      }
+
+      const pullRequest = await this.findOpenPullRequestForBranch(worktree.branch, workspacePath);
+      if (pullRequest === null) {
+        throw new Error(`No open pull request was found for branch ${worktree.branch}.`);
+      }
+
+      await this.runExternalCommand(
+        "gh",
+        ["pr", "merge", String(pullRequest.number), "--auto", "--squash", "--delete-branch"],
+        workspacePath
+      );
+      mergedPrs.push(`#${pullRequest.number}`);
+    }
+
+    await this.runGitCommand(["pull", "--rebase"], workspacePath);
+    await syncBeadsWorkspace((args, cwd) => this.runBdCommand(args, cwd), workspacePath);
+    await this.refresh();
+    vscode.window.showInformationMessage(
+      `Queued auto-merge for ${mergedPrs.join(", ")} and synced Beads.`
     );
   }
 
@@ -584,76 +754,16 @@ export class BeadsViewProvider implements vscode.WebviewViewProvider, vscode.Dis
     return false;
   }
 
-  private async pickAssignModel(currentModel: string | undefined) {
-    const trimmedCurrent = currentModel?.trim() ?? "";
-    const options = [
-      ...new Set([trimmedCurrent, ...ASSIGN_MODEL_OPTIONS].filter((model) => model !== ""))
-    ];
-    const picked = await vscode.window.showQuickPick(
-      [
-        ...options.map((model, index) => ({
-          label: model,
-          description: index === 0 && trimmedCurrent !== "" ? "current" : "model"
-        })),
-        { label: "Custom...", description: "enter another model id" }
-      ],
-      {
-        title: "Assign AI Model",
-        placeHolder: "Choose the model that will work on this bead",
-        ignoreFocusOut: true
-      }
-    );
-    if (picked === undefined) {
-      return undefined;
-    }
-    if (picked.label !== "Custom...") {
-      return picked.label;
-    }
-
-    const customModel = await vscode.window.showInputBox({
-      title: "Assign AI Model",
-      prompt: "Model id",
-      value: trimmedCurrent || DEFAULT_ASSIGN_MODEL,
-      placeHolder: DEFAULT_ASSIGN_MODEL,
-      ignoreFocusOut: true,
-      validateInput: (value) => (value.trim() === "" ? "Model is required." : undefined)
-    });
-
-    return customModel?.trim();
+  private resolveAssignModel(currentModel: string | undefined) {
+    return currentModel?.trim() || DEFAULT_ASSIGN_MODEL;
   }
 
-  private async confirmAssignContext(
+  private resolveAssignSsot(
     workspacePath: string,
     issueId: string,
-    title: string | undefined,
-    model: string,
     currentSsot: string | undefined
   ) {
-    const suggestedSsot = currentSsot?.trim() || this.inferAssignSsot(workspacePath, issueId);
-    const detail = `${issueId}${title ? `: ${title}` : ""}\nModel: ${model}\nSSOT/context: ${suggestedSsot}`;
-    const confirmation = await vscode.window.showInformationMessage(
-      "Start AI work with this model and SSOT/context?",
-      { modal: true, detail },
-      "Start",
-      "Edit Context"
-    );
-    if (confirmation === undefined) {
-      return undefined;
-    }
-    if (confirmation === "Start") {
-      return suggestedSsot;
-    }
-
-    const editedSsot = await vscode.window.showInputBox({
-      title: "SSOT / Context",
-      prompt: "Source of truth or context the AI should use",
-      value: suggestedSsot,
-      ignoreFocusOut: true,
-      validateInput: (value) =>
-        value.trim() === "" ? "SSOT/context is required for AI assignment." : undefined
-    });
-
-    return editedSsot?.trim();
+    return currentSsot?.trim() || this.inferAssignSsot(workspacePath, issueId);
   }
 
   private inferAssignSsot(workspacePath: string, issueId: string) {
@@ -662,6 +772,174 @@ export class BeadsViewProvider implements vscode.WebviewViewProvider, vscode.Dis
     );
 
     return [`bd:${issueId}`, ...references].join(", ");
+  }
+
+  private resolveAssignWorktree(
+    workspacePath: string,
+    issueId: string,
+    currentWorktree: string | undefined
+  ) {
+    const trimmed = currentWorktree?.trim();
+    if (trimmed) {
+      return trimmed;
+    }
+
+    const safeIssueId = issueId.replace(/[^a-zA-Z0-9._-]+/g, "-").slice(0, 80);
+    return path.join(path.dirname(workspacePath), `${path.basename(workspacePath)}-${safeIssueId}`);
+  }
+
+  private async resolveDependencyWorktrees(
+    workspacePath: string,
+    dependencies: BeadsExecutionTarget[]
+  ) {
+    const knownWorktrees = await this.listGitWorktrees(workspacePath);
+    const knownByPath = new Map(
+      knownWorktrees.map((worktree) => [path.resolve(worktree.path), worktree])
+    );
+    const resolved: GitWorktreeInfo[] = [];
+
+    for (const dependency of dependencies) {
+      const worktreeHint = dependency.worktree?.trim();
+      if (!worktreeHint) {
+        throw new Error(`Bead ${dependency.issueId} has no worktree metadata.`);
+      }
+
+      const requestedPath = path.resolve(workspacePath, worktreeHint);
+      const worktree = knownByPath.get(requestedPath);
+      if (!worktree) {
+        throw new Error(
+          `Worktree for bead ${dependency.issueId} is not registered with git worktree list: ${worktreeHint}`
+        );
+      }
+      resolved.push(worktree);
+    }
+
+    return [...new Map(resolved.map((worktree) => [worktree.path, worktree])).values()];
+  }
+
+  private async ensureAgentWorktree(workspacePath: string, issueId: string, worktreeHint: string) {
+    const worktreePath = path.resolve(workspacePath, worktreeHint);
+    const knownWorktrees = await this.listGitWorktrees(workspacePath);
+    const knownWorktree = knownWorktrees.find(
+      (worktree) => path.resolve(worktree.path) === worktreePath
+    );
+    if (knownWorktree) {
+      return knownWorktree.path;
+    }
+
+    if (fs.existsSync(worktreePath)) {
+      throw new Error(
+        `Worktree path already exists but is not registered with git worktree list: ${worktreePath}`
+      );
+    }
+
+    const branchName = `agent/${issueId.replace(/[^a-zA-Z0-9._-]+/g, "-").slice(0, 80)}`;
+    const branchExists = await this.gitRefExists(workspacePath, `refs/heads/${branchName}`);
+    await this.runGitCommand(
+      branchExists
+        ? ["worktree", "add", worktreePath, branchName]
+        : ["worktree", "add", "-b", branchName, worktreePath, "HEAD"],
+      workspacePath
+    );
+
+    return worktreePath;
+  }
+
+  private async gitRefExists(cwd: string, refName: string) {
+    try {
+      await this.runGitCommand(["show-ref", "--verify", "--quiet", refName], cwd);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  private async listGitWorktrees(cwd: string) {
+    const stdout = await this.runGitCommand(["worktree", "list", "--porcelain"], cwd);
+    const worktrees: GitWorktreeInfo[] = [];
+    let current: GitWorktreeInfo | null = null;
+
+    for (const rawLine of stdout.split(/\r?\n/)) {
+      const line = rawLine.trim();
+      if (line === "") {
+        if (current !== null) {
+          worktrees.push(current);
+          current = null;
+        }
+        continue;
+      }
+
+      const [key, ...valueParts] = line.split(" ");
+      const value = valueParts.join(" ");
+      if (key === "worktree") {
+        if (current !== null) {
+          worktrees.push(current);
+        }
+        current = { path: value, branch: "", head: "" };
+      } else if (current !== null && key === "branch") {
+        current.branch = value.replace(/^refs\/heads\//, "");
+      } else if (current !== null && key === "HEAD") {
+        current.head = value;
+      }
+    }
+
+    if (current !== null) {
+      worktrees.push(current);
+    }
+
+    return worktrees;
+  }
+
+  private async assertWorktreesReadyForMerge(worktrees: GitWorktreeInfo[]) {
+    for (const worktree of worktrees) {
+      try {
+        await this.runGitCommand(
+          ["merge-base", "--is-ancestor", "origin/main", "HEAD"],
+          worktree.path
+        );
+      } catch {
+        throw new Error(
+          `Worktree ${worktree.path} does not contain origin/main; rebase or merge the latest base before PR merge.`
+        );
+      }
+
+      const status = await this.runGitCommand(["status", "--porcelain"], worktree.path);
+      if (status.trim() !== "") {
+        throw new Error(
+          `Worktree ${worktree.path} has uncommitted changes; commit or clean it before PR merge.`
+        );
+      }
+    }
+  }
+
+  private async findOpenPullRequestForBranch(branch: string, cwd: string) {
+    let stdout = "";
+    try {
+      stdout = await this.runExternalCommand(
+        "gh",
+        ["pr", "view", branch, "--json", "number,state,isDraft,url"],
+        cwd
+      );
+    } catch {
+      return null;
+    }
+
+    const parsed = JSON.parse(stdout) as {
+      number?: unknown;
+      state?: unknown;
+      isDraft?: unknown;
+      url?: unknown;
+    };
+    if (typeof parsed.number !== "number") {
+      return null;
+    }
+    if (parsed.state !== "OPEN") {
+      return null;
+    }
+    if (parsed.isDraft === true) {
+      throw new Error(`Pull request #${parsed.number} for ${branch} is still draft.`);
+    }
+    return { number: parsed.number, url: typeof parsed.url === "string" ? parsed.url : "" };
   }
 
   private async promptAndCreateBead(workspacePath: string) {
@@ -1162,6 +1440,34 @@ export class BeadsViewProvider implements vscode.WebviewViewProvider, vscode.Dis
         reject(
           new Error(
             stderr.trim() || `${gitPath} ${args.join(" ")} failed with exit code ${code ?? -1}.`
+          )
+        );
+      });
+    });
+  }
+
+  private async runExternalCommand(command: string, args: string[], cwd: string) {
+    return new Promise<string>((resolve, reject) => {
+      const child = cp.spawn(command, args, { cwd });
+      let stdout = "";
+      let stderr = "";
+      child.stdout.on("data", (chunk) => {
+        stdout += chunk.toString();
+      });
+      child.stderr.on("data", (chunk) => {
+        stderr += chunk.toString();
+      });
+      child.on("error", (error) => {
+        reject(error);
+      });
+      child.on("close", (code) => {
+        if (code === 0) {
+          resolve(stdout);
+          return;
+        }
+        reject(
+          new Error(
+            stderr.trim() || `${command} ${args.join(" ")} failed with exit code ${code ?? -1}.`
           )
         );
       });

--- a/src/beadsWebview.ts
+++ b/src/beadsWebview.ts
@@ -46,6 +46,10 @@ function isDerivedMergeTask(item: BeadItem) {
   return item.synthetic && item.syntheticKind === "parallel-pr-merge";
 }
 
+function encodeJsonData(value: unknown) {
+  return escapeHtml(encodeURIComponent(JSON.stringify(value)));
+}
+
 function renderBeadsDependencyGraph(
   items: BeadItem[],
   workspacePath: string,
@@ -118,13 +122,15 @@ function renderBeadsDependencyGraph(
         ]
           .filter((line) => line !== "")
           .join("");
-        const assignDisabled = normalizedStatus === "closed" || derivedMerge ? " disabled" : "";
-        const assignTitle = derivedMerge
-          ? "Derived merge tasks cannot be started with AI."
-          : normalizedStatus === "closed"
+        const assignDisabled = normalizedStatus === "closed" ? " disabled" : "";
+        const assignTitle =
+          normalizedStatus === "closed"
             ? "Closed beads cannot be started."
-            : "Choose an AI model, attach SSOT/context, and mark this bead in progress.";
-        return `<div class="graphNode ${node.critical ? "criticalGraphNode" : ""}" data-graph-id="${escapeHtml(item.id)}" data-graph-level="${level}" data-graph-lane="${lane}" data-status="${escapeHtml(normalizedStatus)}" data-critical="${node.critical ? "1" : "0"}" style="--graph-x:${x}px;--graph-y:${y}px"><div class="graphNodeTop"><span class="typeBadge type-${escapeHtml(normalizedType)}">${escapeHtml(item.type)}</span>${node.critical ? '<span class="criticalBadge">Critical</span>' : ""}</div><div class="beadId">${escapeHtml(item.id)}</div><div class="graphNodeTitle">${escapeHtml(item.title)}</div><div class="graphNodeBadges"><span class="statusBadge status-${escapeHtml(normalizedStatus.replace(/_/g, "-"))}">${escapeHtml(beadStatusLabel(normalizedStatus))}</span><span class="priorityBadge priority-${escapeHtml(normalizedPriority.toLowerCase())}">${escapeHtml(normalizedPriority)}</span>${derivedMerge ? `<span class="executionBadge mergeBadge">Merge PR</span>` : ""}${modelLabel === "" ? "" : `<span class="executionBadge modelBadge">Model ${escapeHtml(modelLabel)}</span>`}${ssotLabel === "" ? "" : `<span class="executionBadge ssotBadge">SSOT</span>`}</div>${dependencyLines === "" ? "" : `<div class="graphRelations">${dependencyLines}</div>`}<div class="graphNodeActions"><button class="assignStartBead" type="button" data-assign-start-id="${escapeHtml(item.id)}" data-assign-start-workspace="${escapeHtml(workspacePath)}" data-assign-start-title="${escapeHtml(item.title)}" data-assign-start-agent="${escapeHtml(item.agent.trim())}" data-assign-start-model="${escapeHtml(item.model.trim())}" data-assign-start-ssot="${escapeHtml(ssotLabel)}" data-assign-start-worktree="${escapeHtml(item.worktree.trim())}" title="${escapeHtml(assignTitle)}"${assignDisabled}>Start AI</button></div></div>`;
+            : "Assign the default AI model, attach SSOT/context, and mark this bead in progress.";
+        const actionHtml = derivedMerge
+          ? `<button class="mergeParallelPrs" type="button" data-merge-id="${escapeHtml(item.id)}" data-merge-workspace="${escapeHtml(workspacePath)}" data-merge-title="${escapeHtml(item.title)}" data-merge-dependencies="${escapeHtml(item.dependencyIds.join(","))}" title="Check agent worktrees, auto-merge their PRs, then sync Beads.">Merge PRs</button>`
+          : `<button class="assignStartBead" type="button" data-assign-start-id="${escapeHtml(item.id)}" data-assign-start-workspace="${escapeHtml(workspacePath)}" data-assign-start-title="${escapeHtml(item.title)}" data-assign-start-agent="${escapeHtml(item.agent.trim())}" data-assign-start-model="${escapeHtml(item.model.trim())}" data-assign-start-ssot="${escapeHtml(ssotLabel)}" data-assign-start-worktree="${escapeHtml(item.worktree.trim())}" title="${escapeHtml(assignTitle)}"${assignDisabled}>Start AI</button>`;
+        return `<div class="graphNode ${node.critical ? "criticalGraphNode" : ""}" data-graph-id="${escapeHtml(item.id)}" data-graph-level="${level}" data-graph-lane="${lane}" data-status="${escapeHtml(normalizedStatus)}" data-critical="${node.critical ? "1" : "0"}" style="--graph-x:${x}px;--graph-y:${y}px"><div class="graphNodeTop"><span class="typeBadge type-${escapeHtml(normalizedType)}">${escapeHtml(item.type)}</span>${node.critical ? '<span class="criticalBadge">Critical</span>' : ""}</div><div class="beadId">${escapeHtml(item.id)}</div><div class="graphNodeTitle">${escapeHtml(item.title)}</div><div class="graphNodeBadges"><span class="statusBadge status-${escapeHtml(normalizedStatus.replace(/_/g, "-"))}">${escapeHtml(beadStatusLabel(normalizedStatus))}</span><span class="priorityBadge priority-${escapeHtml(normalizedPriority.toLowerCase())}">${escapeHtml(normalizedPriority)}</span>${derivedMerge ? `<span class="executionBadge mergeBadge">Merge PR</span>` : ""}${modelLabel === "" ? "" : `<span class="executionBadge modelBadge">Model ${escapeHtml(modelLabel)}</span>`}${ssotLabel === "" ? "" : `<span class="executionBadge ssotBadge">SSOT</span>`}</div>${dependencyLines === "" ? "" : `<div class="graphRelations">${dependencyLines}</div>`}<div class="graphNodeActions">${actionHtml}</div></div>`;
       })
       .join("");
   }).join("");
@@ -198,6 +204,23 @@ export function renderBeadsWebviewHtml(
           }
         }
         const workspaceTitle = showWorkspaceLabel ? group.workspace : "Beads";
+        const parallelStartTargets = flatItems
+          .map((entry) => entry.item)
+          .filter((item) => {
+            const status = normalizeBeadStatus(item.status);
+            return (
+              item.parallelizable &&
+              !item.synthetic &&
+              (status === "open" || status === "in_progress")
+            );
+          })
+          .map((item) => ({
+            issueId: item.id,
+            title: item.title,
+            model: item.model,
+            ssot: item.ssot,
+            worktree: item.worktree
+          }));
         const workspaceSummary = [
           `<span class="summaryPill">${flatItems.length} total</span>`,
           `<span class="summaryPill activeSummary">${activeCount} active</span>`,
@@ -310,8 +333,12 @@ export function renderBeadsWebviewHtml(
           group.workspacePath,
           agentAliases
         );
+        const parallelAction =
+          parallelStartTargets.length > 0
+            ? `<button class="startParallelBeads workspaceAction" type="button" data-start-parallel-workspace="${escapeHtml(group.workspacePath)}" data-start-parallel-items="${encodeJsonData(parallelStartTargets)}" title="Assign and start all parallel-ready tasks with Copilot">${parallelStartTargets.length} Start Parallel</button>`
+            : "";
 
-        return `<section data-workspace-path="${escapeHtml(group.workspacePath)}"><div class="workspaceHeader"><div class="workspaceName">${escapeHtml(workspaceTitle)}</div><div class="workspaceSummary">${workspaceSummary}</div></div><div class="tableWrap"><svg class="hierarchyOverlay" aria-hidden="true"></svg><table><thead><tr><th><button class="sortToggle" data-sort-key="type" type="button" title="Sort by type">Type <span class="sortIcon" data-sort-key="type"> </span></button></th><th>Parallel</th><th>Title</th><th>Status</th><th><button class="sortToggle" data-sort-key="priority" type="button" title="Sort by priority">Priority <span class="sortIcon" data-sort-key="priority"> </span></button></th><th><button class="sortToggle" data-sort-key="updated" type="button" title="Sort by updated">Updated <span class="sortIcon" data-sort-key="updated">▼</span></button></th></tr></thead><tbody>${itemRows}</tbody></table></div>${graphHtml}</section>`;
+        return `<section data-workspace-path="${escapeHtml(group.workspacePath)}"><div class="workspaceHeader"><div class="workspaceName">${escapeHtml(workspaceTitle)}</div><div class="workspaceHeaderRight"><div class="workspaceSummary">${workspaceSummary}</div>${parallelAction}</div></div><div class="tableWrap"><svg class="hierarchyOverlay" aria-hidden="true"></svg><table><thead><tr><th><button class="sortToggle" data-sort-key="type" type="button" title="Sort by type">Type <span class="sortIcon" data-sort-key="type"> </span></button></th><th>Parallel</th><th>Title</th><th>Status</th><th><button class="sortToggle" data-sort-key="priority" type="button" title="Sort by priority">Priority <span class="sortIcon" data-sort-key="priority"> </span></button></th><th><button class="sortToggle" data-sort-key="updated" type="button" title="Sort by updated">Updated <span class="sortIcon" data-sort-key="updated">▼</span></button></th></tr></thead><tbody>${itemRows}</tbody></table></div>${graphHtml}</section>`;
       })
       .join("");
     const emptyHtml = result.emptyWorkspaces
@@ -389,7 +416,9 @@ body[data-has-sync-warnings="1"] #syncBeads .toolbarActionLabel{font-weight:700;
 .toolbarActionLabel{color:var(--vscode-button-foreground);font-size:11px;line-height:1;}
 .workspaceHeader{display:flex;align-items:center;justify-content:space-between;gap:8px;margin:8px 0 5px;min-width:0;}
 .workspaceName{font-size:12px;font-weight:700;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
+.workspaceHeaderRight{display:flex;align-items:center;justify-content:flex-end;gap:6px;flex-wrap:wrap;min-width:0;}
 .workspaceSummary{display:flex;justify-content:flex-end;gap:4px;flex-wrap:wrap;}
+.workspaceAction{height:22px;padding:0 8px;border-radius:6px;border-color:rgba(34,197,94,.55);background:rgba(34,197,94,.16);color:var(--vscode-testing-iconPassed,#22c55e);font-weight:750;white-space:nowrap;}
 .summaryPill{display:inline-flex;align-items:center;min-height:18px;padding:1px 6px;border:1px solid var(--vscode-panel-border);border-radius:999px;background:rgba(128,128,128,.1);color:var(--vscode-descriptionForeground);font-size:10px;font-weight:600;white-space:nowrap;}
 .activeSummary{border-color:rgba(59,130,246,.4);color:var(--vscode-textLink-foreground,#3b82f6);}
 .blockedSummary{border-color:rgba(239,68,68,.5);color:var(--vscode-errorForeground,#ef4444);}
@@ -497,13 +526,15 @@ th:nth-child(1){width:52px;}th:nth-child(2){width:72px;}th:nth-child(4){width:78
 .graphRelation{display:grid;grid-template-columns:54px minmax(0,1fr);gap:5px;font-size:10px;color:var(--vscode-descriptionForeground);line-height:1.35;}
 .graphRelation span{font-weight:700;color:var(--vscode-foreground);}
 .graphNodeActions{display:flex;justify-content:flex-end;margin-top:8px;}
-.assignStartBead{height:24px;padding:0 8px;font-weight:650;}
+.assignStartBead,.mergeParallelPrs{height:24px;padding:0 8px;font-weight:650;}
+.mergeParallelPrs{border-color:rgba(249,115,22,.55);background:rgba(249,115,22,.16);color:var(--vscode-charts-orange,#f97316);}
 .assignStartBead:disabled{opacity:.45;cursor:default;}
 @media (max-width:560px){
   .toolbar{grid-template-columns:1fr;gap:6px;}
   .toolbarActions{justify-content:stretch;}
   .toolbarActions .actionBtn{flex:1 1 0;min-width:0;}
   .workspaceHeader{align-items:flex-start;flex-direction:column;gap:4px;}
+  .workspaceHeaderRight{justify-content:flex-start;}
   .workspaceSummary{justify-content:flex-start;}
   .hierarchyOverlay{display:none;}
   table,tbody{display:block;}

--- a/tests/beadsProtocol.test.ts
+++ b/tests/beadsProtocol.test.ts
@@ -25,6 +25,21 @@ describe("isBeadsRequestMessage", () => {
         ssot: "AGENTS.md, .beads/issues.jsonl"
       })
     ).toBe(true);
+    expect(
+      isBeadsRequestMessage({
+        command: "startParallelBeads",
+        workspacePath: "/tmp/demo",
+        items: [{ issueId: "neo-1", title: "Demo", worktree: "../repo-neo-1" }]
+      })
+    ).toBe(true);
+    expect(
+      isBeadsRequestMessage({
+        command: "mergeParallelPrs",
+        issueId: "merge:neo-epic",
+        workspacePath: "/tmp/demo",
+        dependencies: [{ issueId: "neo-1", worktree: "../repo-neo-1" }]
+      })
+    ).toBe(true);
   });
 
   it("rejects malformed messages", () => {
@@ -40,6 +55,21 @@ describe("isBeadsRequestMessage", () => {
         issueId: "neo-1",
         workspacePath: "/tmp/demo",
         model: 1234
+      })
+    ).toBe(false);
+    expect(
+      isBeadsRequestMessage({
+        command: "startParallelBeads",
+        workspacePath: "/tmp/demo",
+        items: [{ title: "missing id" }]
+      })
+    ).toBe(false);
+    expect(
+      isBeadsRequestMessage({
+        command: "mergeParallelPrs",
+        issueId: "merge:neo-epic",
+        workspacePath: "/tmp/demo",
+        dependencies: [{ issueId: 1234 }]
       })
     ).toBe(false);
     expect(isBeadsRequestMessage({ command: "unknown" })).toBe(false);

--- a/tests/beadsWebviewMetadata.test.ts
+++ b/tests/beadsWebviewMetadata.test.ts
@@ -46,6 +46,8 @@ describe("beads webview presentation metadata", () => {
     expect(beadsWebview).toContain("dependencyOverlay");
     expect(beadsWebview).toContain("criticalGraphNode");
     expect(beadsWebview).toContain("Start AI");
+    expect(beadsWebview).toContain("Start Parallel");
+    expect(beadsWebview).toContain("data-start-parallel-items");
     expect(beadsWebview).toContain("data-assign-start-model");
     expect(beadsWebview).toContain("data-assign-start-ssot");
     expect(beadsWebview).toContain("data-assign-start-worktree");
@@ -85,23 +87,31 @@ describe("beads webview presentation metadata", () => {
     );
     expect(beadsMain).toContain("renderDependencyGraphOverlays");
     expect(beadsMain).toContain('command: "assignStartBead"');
+    expect(beadsMain).toContain('command: "startParallelBeads"');
     expect(beadsMain).toContain("detailsCell.colSpan = 6");
   });
 
-  it("starts AI work with model and inferred SSOT context", () => {
-    expect(beadsView).toContain("Assign AI Model");
-    expect(beadsView).toContain("Start AI work with this model and SSOT/context?");
+  it("starts AI work with automatic model, SSOT, and worktree context", () => {
+    expect(beadsView).toContain("DEFAULT_ASSIGN_MODEL");
+    expect(beadsView).toContain("resolveAssignModel");
+    expect(beadsView).toContain("resolveAssignSsot");
+    expect(beadsView).toContain("resolveAssignWorktree");
+    expect(beadsView).toContain("ensureAgentWorktree");
+    expect(beadsView).toContain('"worktree", "add"');
     expect(beadsView).toContain("inferAssignSsot");
     expect(beadsView).toContain("deriveParallelMergeItems");
     expect(beadsView).toContain("openAssignAgentSession");
+    expect(beadsView).toContain("startParallelBeads");
     expect(beadsView).toContain("workbench.action.chat.openSessionWithPrompt.copilotcli");
     expect(beadsView).toContain("AGENTS.md");
     expect(beadsView).toContain(".beads/issues.jsonl");
     expect(beadsView).toContain("README.md");
-    expect(beadsView).toContain("`model=$" + "{model}`");
-    expect(beadsView).toContain("`ssot=$" + "{ssot}`");
+    expect(beadsView).toContain("`model=$" + "{values.model}`");
+    expect(beadsView).toContain("`ssot=$" + "{values.ssot}`");
+    expect(beadsView).toContain("`worktree=$" + "{worktree}`");
     expect(beadsView).toContain("Inspect the bead details with bd show");
     expect(beadsView).not.toContain("Assign Agent");
+    expect(beadsView).not.toContain("Assign AI Model");
   });
 
   it("anonymizes email-like agent identities in display labels", () => {
@@ -112,6 +122,12 @@ describe("beads webview presentation metadata", () => {
   it("surfaces derived parallel PR merge tasks in the table and graph", () => {
     expect(beadsWebview).toContain("parallel-pr-merge");
     expect(beadsWebview).toContain("Merge PR");
+    expect(beadsWebview).toContain("Merge PRs");
+    expect(beadsWebview).toContain("data-merge-dependencies");
     expect(beadsMain).toContain("Derived merge task");
+    expect(beadsMain).toContain('command: "mergeParallelPrs"');
+    expect(beadsView).toContain("mergeParallelPullRequests");
+    expect(beadsView).toContain("assertWorktreesReadyForMerge");
+    expect(beadsView).toContain("gh");
   });
 });

--- a/web/beadsMain.ts
+++ b/web/beadsMain.ts
@@ -136,6 +136,33 @@ function decodeRowItem(row: BeadRow): BeadRowItem | null {
   }
 }
 
+function decodeEncodedJson<T>(encoded: string | undefined): T | null {
+  if (!encoded) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(decodeURIComponent(encoded)) as T;
+  } catch {
+    return null;
+  }
+}
+
+function toExecutionTarget(item: BeadRowItem) {
+  return {
+    issueId: item.id,
+    title: item.title || "",
+    model: item.model || undefined,
+    ssot: item.ssot || undefined,
+    worktree: item.worktree || undefined
+  };
+}
+
+function findSectionRows(button: HTMLElement) {
+  const section = button.closest("section[data-workspace-path]");
+  return section === null ? [] : getVisibleBeadRows(section);
+}
+
 function closeContextMenu() {
   rowContextMenu.classList.remove("open");
   contextMenuRow = null;
@@ -816,6 +843,26 @@ for (const button of Array.from(
     vscode.postMessage({ command: "syncBeads", workspacePath });
   });
 }
+for (const button of Array.from(
+  document.querySelectorAll<HTMLButtonElement>(".startParallelBeads")
+)) {
+  button.addEventListener("click", () => {
+    const workspacePath = button.dataset.startParallelWorkspace || "";
+    const items = decodeEncodedJson<
+      Array<{
+        issueId: string;
+        title?: string;
+        model?: string;
+        ssot?: string;
+        worktree?: string;
+      }>
+    >(button.dataset.startParallelItems);
+    if (!bdAvailable || workspacePath === "" || items === null || items.length === 0) {
+      return;
+    }
+    vscode.postMessage({ command: "startParallelBeads", workspacePath, items });
+  });
+}
 for (const button of Array.from(document.querySelectorAll<HTMLButtonElement>(".assignStartBead"))) {
   button.addEventListener("click", () => {
     const issueId = button.dataset.assignStartId || "";
@@ -832,6 +879,34 @@ for (const button of Array.from(document.querySelectorAll<HTMLButtonElement>(".a
       model: normalizeOptionalDatasetValue(button.dataset.assignStartModel),
       ssot: normalizeOptionalDatasetValue(button.dataset.assignStartSsot),
       worktree: normalizeOptionalDatasetValue(button.dataset.assignStartWorktree)
+    });
+  });
+}
+for (const button of Array.from(
+  document.querySelectorAll<HTMLButtonElement>(".mergeParallelPrs")
+)) {
+  button.addEventListener("click", () => {
+    const issueId = button.dataset.mergeId || "";
+    const workspacePath = button.dataset.mergeWorkspace || "";
+    const dependencyIds = (button.dataset.mergeDependencies || "")
+      .split(",")
+      .map((id) => id.trim())
+      .filter((id) => id !== "");
+    if (!bdAvailable || issueId === "" || workspacePath === "" || dependencyIds.length === 0) {
+      return;
+    }
+
+    const dependencySet = new Set(dependencyIds);
+    const dependencies = findSectionRows(button)
+      .map((row) => decodeRowItem(row))
+      .filter((item): item is BeadRowItem => item !== null && dependencySet.has(item.id))
+      .map(toExecutionTarget);
+    vscode.postMessage({
+      command: "mergeParallelPrs",
+      issueId,
+      workspacePath,
+      title: button.dataset.mergeTitle || "",
+      dependencies
     });
   });
 }


### PR DESCRIPTION
## Summary

- Add one-click multi-agent start and guarded PR merge flows to the Beads view.
- Keep model, SSOT/context, and worktree assignment automatic for Copilot-backed tasks.

## Changes

- Added webview messages and UI controls for Start Parallel and Merge PRs.
- Auto-create or reuse per-task git worktrees during AI assignment.
- Guard parallel PR auto-merge with registered worktree, base ancestry, and clean-worktree checks before invoking GitHub CLI auto-merge.
- Updated README and metadata tests for the new workflow.

## Testing

- pnpm run format:fix
- pnpm run lint
- pnpm run typecheck
- pnpm test

## Notes

- Direct push to main is blocked by branch protection, so this work is published as a PR.
- Local bd sync was attempted but the installed bd CLI returned unknown command "sync".