### PR TITLE
feat: add SSOT usage manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,26 @@ When multiple ready tasks can run in parallel, **Start Parallel** assigns and st
 
 These hints are visual metadata. Beads ready/blocking behavior still comes from issue status and dependencies.
 
+## SSOT Usage
+
+The extension reads SSOT/context from `ssot-usage.json`, `.beads/ssot-usage.json`, or `.codex/ssot-usage.json` before falling back to built-in workspace defaults. The manifest can list default refs and richer context records:
+
+```json
+{
+  "version": 1,
+  "default": ["bd:${issueId}", "AGENTS.md", ".beads/issues.jsonl", "README.md"],
+  "contexts": [
+    {
+      "id": "agent-rules",
+      "path": "AGENTS.md",
+      "use": "Repository-local instructions and workflow rules."
+    }
+  ]
+}
+```
+
+Only existing local paths are added; refs such as `bd:${issueId}` and URLs are kept as-is.
+
 For derived parallel merge tasks, **Merge PRs** checks the registered agent worktrees before asking GitHub CLI to auto-merge their branch PRs. It blocks if a worktree is not registered, does not contain `origin/main`, or has uncommitted changes.
 
 You can run the same guard manually:

--- a/src/beadsView.ts
+++ b/src/beadsView.ts
@@ -33,6 +33,11 @@ type CreateBeadType = "task" | "feature" | "bug" | "epic" | "chore";
 type CreateBeadStatus = "open" | "in_progress" | "blocked" | "closed";
 type CreateBeadPriority = "P0" | "P1" | "P2" | "P3" | "P4";
 const DEFAULT_ASSIGN_MODEL = "gpt-5-codex";
+const SSOT_USAGE_MANIFEST_CANDIDATES = [
+  "ssot-usage.json",
+  ".beads/ssot-usage.json",
+  ".codex/ssot-usage.json"
+];
 const ASSIGN_CONTEXT_CANDIDATES = [
   "AGENTS.md",
   ".codex",
@@ -767,11 +772,79 @@ export class BeadsViewProvider implements vscode.WebviewViewProvider, vscode.Dis
   }
 
   private inferAssignSsot(workspacePath: string, issueId: string) {
+    const manifestEntries = this.loadAssignSsotManifestEntries(workspacePath, issueId);
+    if (manifestEntries.length > 0) {
+      return manifestEntries.join(", ");
+    }
+
     const references = ASSIGN_CONTEXT_CANDIDATES.filter((candidate) =>
       fs.existsSync(path.join(workspacePath, candidate))
     );
 
     return [`bd:${issueId}`, ...references].join(", ");
+  }
+
+  private loadAssignSsotManifestEntries(workspacePath: string, issueId: string) {
+    for (const candidate of SSOT_USAGE_MANIFEST_CANDIDATES) {
+      const manifestPath = path.join(workspacePath, candidate);
+      if (!fs.existsSync(manifestPath)) {
+        continue;
+      }
+
+      try {
+        const parsed = JSON.parse(fs.readFileSync(manifestPath, "utf8")) as Record<string, unknown>;
+        const entries = this.normalizeSsotManifestEntries(workspacePath, issueId, parsed);
+        if (entries.length > 0) {
+          return entries;
+        }
+      } catch {
+        continue;
+      }
+    }
+
+    return [];
+  }
+
+  private normalizeSsotManifestEntries(
+    workspacePath: string,
+    issueId: string,
+    manifest: Record<string, unknown>
+  ) {
+    const values: string[] = [];
+    const pushValue = (value: unknown) => {
+      if (typeof value === "string") {
+        values.push(value);
+        return;
+      }
+      if (typeof value !== "object" || value === null || Array.isArray(value)) {
+        return;
+      }
+
+      const record = value as Record<string, unknown>;
+      const candidate = record.ref ?? record.path ?? record.url ?? record.id;
+      if (typeof candidate === "string") {
+        values.push(candidate);
+      }
+    };
+
+    if (Array.isArray(manifest.default)) {
+      manifest.default.forEach(pushValue);
+    }
+    if (Array.isArray(manifest.contexts)) {
+      manifest.contexts.forEach(pushValue);
+    }
+
+    const normalized = values
+      .map((value) => value.replace(/\$\{issueId\}/g, issueId).trim())
+      .filter((value) => value !== "")
+      .filter((value) => {
+        if (/^[a-z][a-z0-9+.-]*:/i.test(value)) {
+          return true;
+        }
+        return fs.existsSync(path.join(workspacePath, value));
+      });
+
+    return [...new Set(normalized)];
   }
 
   private resolveAssignWorktree(

--- a/ssot-usage.json
+++ b/ssot-usage.json
@@ -1,0 +1,39 @@
+{
+  "version": 1,
+  "description": "SSOT/context manifest used when assigning Beads tasks to agents.",
+  "default": [
+    "bd:${issueId}",
+    "AGENTS.md",
+    ".beads/issues.jsonl",
+    "README.md",
+    "CONTRIBUTING.md",
+    "docs"
+  ],
+  "contexts": [
+    {
+      "id": "agent-rules",
+      "path": "AGENTS.md",
+      "use": "Repository-local instructions and workflow rules."
+    },
+    {
+      "id": "beads-state",
+      "path": ".beads/issues.jsonl",
+      "use": "Task status, dependencies, and execution metadata."
+    },
+    {
+      "id": "product-readme",
+      "path": "README.md",
+      "use": "User-facing behavior and extension workflow."
+    },
+    {
+      "id": "contributing",
+      "path": "CONTRIBUTING.md",
+      "use": "Development and contribution conventions."
+    },
+    {
+      "id": "docs",
+      "path": "docs",
+      "use": "Longer-lived project notes and release guard documentation."
+    }
+  ]
+}

--- a/tests/beadsWebviewMetadata.test.ts
+++ b/tests/beadsWebviewMetadata.test.ts
@@ -98,6 +98,10 @@ describe("beads webview presentation metadata", () => {
     expect(beadsView).toContain("resolveAssignWorktree");
     expect(beadsView).toContain("ensureAgentWorktree");
     expect(beadsView).toContain('"worktree", "add"');
+    expect(beadsView).toContain("SSOT_USAGE_MANIFEST_CANDIDATES");
+    expect(beadsView).toContain("loadAssignSsotManifestEntries");
+    expect(beadsView).toContain("normalizeSsotManifestEntries");
+    expect(beadsView).toContain("ssot-usage.json");
     expect(beadsView).toContain("inferAssignSsot");
     expect(beadsView).toContain("deriveParallelMergeItems");
     expect(beadsView).toContain("openAssignAgentSession");

--- a/tests/ssotUsageManifest.test.ts
+++ b/tests/ssotUsageManifest.test.ts
@@ -1,0 +1,39 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const repoRoot = join(import.meta.dirname, "..");
+
+describe("ssot-usage manifest", () => {
+  it("declares default agent context refs as JSON", () => {
+    const manifest = JSON.parse(readFileSync(join(repoRoot, "ssot-usage.json"), "utf8")) as Record<
+      string,
+      unknown
+    >;
+
+    expect(manifest).toMatchObject({
+      version: 1
+    });
+    expect(manifest.default).toEqual(
+      expect.arrayContaining([
+        "bd:$" + "{issueId}",
+        "AGENTS.md",
+        ".beads/issues.jsonl",
+        "README.md"
+      ])
+    );
+    expect(manifest.contexts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "agent-rules",
+          path: "AGENTS.md"
+        }),
+        expect.objectContaining({
+          id: "beads-state",
+          path: ".beads/issues.jsonl"
+        })
+      ])
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Add a JSON SSOT usage manifest for agent task assignment.
- Teach Start AI and Start Parallel to prefer manifest-defined context before built-in defaults.

## Changes

- Added ssot-usage.json with default Beads, agent, README, contributing, and docs context refs.
- Added manifest discovery for ssot-usage.json, .beads/ssot-usage.json, and .codex/ssot-usage.json.
- Filter manifest paths to existing local paths while preserving bd: refs and URLs.
- Updated README and tests for the SSOT manifest flow.

## Testing

- pnpm run format:fix
- pnpm run lint
- pnpm run typecheck
- pnpm test

## Notes

- Local bd sync was attempted but the installed bd CLI returned unknown command sync.