### PR TITLE
fix: harden multi-agent automation

### DIFF
--- a/src/beadsView.ts
+++ b/src/beadsView.ts
@@ -689,15 +689,14 @@ export class BeadsViewProvider implements vscode.WebviewViewProvider, vscode.Dis
         ["pr", "merge", String(pullRequest.number), "--auto", "--squash", "--delete-branch"],
         workspacePath
       );
+      await this.waitForPullRequestMerged(pullRequest.number, workspacePath);
       mergedPrs.push(`#${pullRequest.number}`);
     }
 
     await this.runGitCommand(["pull", "--rebase"], workspacePath);
     await syncBeadsWorkspace((args, cwd) => this.runBdCommand(args, cwd), workspacePath);
     await this.refresh();
-    vscode.window.showInformationMessage(
-      `Queued auto-merge for ${mergedPrs.join(", ")} and synced Beads.`
-    );
+    vscode.window.showInformationMessage(`Merged ${mergedPrs.join(", ")} and synced Beads.`);
   }
 
   private buildAssignAgentPrompt(values: {
@@ -738,7 +737,7 @@ export class BeadsViewProvider implements vscode.WebviewViewProvider, vscode.Dis
   }) {
     const commands = new Set(await vscode.commands.getCommands(true));
     const prompt = this.buildAssignAgentPrompt(values);
-    const resource = vscode.Uri.file(values.workspacePath);
+    const resource = vscode.Uri.file(values.worktree?.trim() || values.workspacePath);
 
     for (const command of COPILOT_ASSIGN_COMMAND_CANDIDATES) {
       if (!commands.has(command)) {
@@ -797,8 +796,9 @@ export class BeadsViewProvider implements vscode.WebviewViewProvider, vscode.Dis
         if (entries.length > 0) {
           return entries;
         }
-      } catch {
-        continue;
+      } catch (error) {
+        const messageText = error instanceof Error ? error.message : "unknown manifest parse error";
+        throw new Error(`Unable to read SSOT usage manifest at ${manifestPath}: ${messageText}`);
       }
     }
 
@@ -845,6 +845,28 @@ export class BeadsViewProvider implements vscode.WebviewViewProvider, vscode.Dis
       });
 
     return [...new Set(normalized)];
+  }
+
+  private async waitForPullRequestMerged(pullRequestNumber: number, cwd: string) {
+    for (let attempt = 0; attempt < 60; attempt += 1) {
+      const stdout = await this.runExternalCommand(
+        "gh",
+        ["pr", "view", String(pullRequestNumber), "--json", "state"],
+        cwd
+      );
+      const parsed = JSON.parse(stdout) as { state?: unknown };
+      if (parsed.state === "MERGED") {
+        return;
+      }
+      if (parsed.state === "CLOSED") {
+        throw new Error(`Pull request #${pullRequestNumber} closed without merging.`);
+      }
+      await new Promise((resolve) => setTimeout(resolve, 5000));
+    }
+
+    throw new Error(
+      `Pull request #${pullRequestNumber} was queued but did not merge within 5 minutes; Beads sync was skipped.`
+    );
   }
 
   private resolveAssignWorktree(

--- a/src/beadsWebview.ts
+++ b/src/beadsWebview.ts
@@ -208,11 +208,7 @@ export function renderBeadsWebviewHtml(
           .map((entry) => entry.item)
           .filter((item) => {
             const status = normalizeBeadStatus(item.status);
-            return (
-              item.parallelizable &&
-              !item.synthetic &&
-              (status === "open" || status === "in_progress")
-            );
+            return item.parallelizable && !item.synthetic && status === "open";
           })
           .map((item) => ({
             issueId: item.id,

--- a/tests/beadsWebviewMetadata.test.ts
+++ b/tests/beadsWebviewMetadata.test.ts
@@ -48,6 +48,7 @@ describe("beads webview presentation metadata", () => {
     expect(beadsWebview).toContain("Start AI");
     expect(beadsWebview).toContain("Start Parallel");
     expect(beadsWebview).toContain("data-start-parallel-items");
+    expect(beadsWebview).toContain('item.parallelizable && !item.synthetic && status === "open"');
     expect(beadsWebview).toContain("data-assign-start-model");
     expect(beadsWebview).toContain("data-assign-start-ssot");
     expect(beadsWebview).toContain("data-assign-start-worktree");
@@ -101,12 +102,14 @@ describe("beads webview presentation metadata", () => {
     expect(beadsView).toContain("SSOT_USAGE_MANIFEST_CANDIDATES");
     expect(beadsView).toContain("loadAssignSsotManifestEntries");
     expect(beadsView).toContain("normalizeSsotManifestEntries");
+    expect(beadsView).toContain("Unable to read SSOT usage manifest at");
     expect(beadsView).toContain("ssot-usage.json");
     expect(beadsView).toContain("inferAssignSsot");
     expect(beadsView).toContain("deriveParallelMergeItems");
     expect(beadsView).toContain("openAssignAgentSession");
     expect(beadsView).toContain("startParallelBeads");
     expect(beadsView).toContain("workbench.action.chat.openSessionWithPrompt.copilotcli");
+    expect(beadsView).toContain("vscode.Uri.file(values.worktree?.trim() || values.workspacePath)");
     expect(beadsView).toContain("AGENTS.md");
     expect(beadsView).toContain(".beads/issues.jsonl");
     expect(beadsView).toContain("README.md");
@@ -132,6 +135,7 @@ describe("beads webview presentation metadata", () => {
     expect(beadsMain).toContain('command: "mergeParallelPrs"');
     expect(beadsView).toContain("mergeParallelPullRequests");
     expect(beadsView).toContain("assertWorktreesReadyForMerge");
+    expect(beadsView).toContain("waitForPullRequestMerged");
     expect(beadsView).toContain("gh");
   });
 });


### PR DESCRIPTION
## Summary

- Harden multi-agent assignment, parallel start, and PR merge behavior.

## Changes

- Open Copilot assignment sessions from the agent worktree when one is available.
- Wait for queued PR auto-merge to actually complete before pulling and syncing Beads.
- Surface invalid SSOT usage manifests instead of silently ignoring parse failures.
- Limit Start Parallel targets to open parallel-ready tasks.
- Add regression metadata checks for the changed behavior.

## Testing

- pnpm run format:fix
- pnpm run lint
- pnpm run typecheck
- pnpm test

## Notes

- bd sync was attempted locally, but this installed bd CLI reports unknown command "sync".