### PR TITLE
chore: release v0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@
 
 <!-- daily-generated:end -->
 
+## [0.3.2] - 2026-06-20
+
+### Added
+
+- Add Beads Table and Graph execution badges for state, owner, model, worktree, SSOT, and dependency warnings.
+- Add dependency lint warnings for ready or sibling tasks that likely need blocked-by edges.
+- Show aggregated multi-agent worktree preflight results before PR merge actions.
+
+### Fixed
+
+- Keep Graph dependency edges aligned while scrolling in Graph mode.
+- Block multi-agent PR merge when any agent worktree is stale, dirty, or detached, with all reasons shown together.
+
+### Changed
+
+- Update GitHub Actions checkout usage to actions/checkout 7.0.0.
+
 ## [0.3.1] - 2026-06-19
 
 ### Added
@@ -298,7 +315,8 @@
 
 Initial release
 
-[Unreleased]: https://github.com/ToppyMicroServices/beads-git-graph/compare/v0.3.1...HEAD
+[Unreleased]: https://github.com/ToppyMicroServices/beads-git-graph/compare/v0.3.2...HEAD
+[0.3.2]: https://github.com/ToppyMicroServices/beads-git-graph/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/ToppyMicroServices/beads-git-graph/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/ToppyMicroServices/beads-git-graph/compare/v0.1.36...v0.3.0
 [0.1.36]: https://github.com/ToppyMicroServices/beads-git-graph/compare/v0.1.35...v0.1.36

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Beads Git Graph
 
 [![MIT License](https://img.shields.io/badge/license-MIT-2ea44f?style=flat-square)](./LICENSE)
-[![Version 0.3.1](https://img.shields.io/badge/version-0.3.1-0366d6?style=flat-square)](./CHANGELOG.md)
+[![Version 0.3.2](https://img.shields.io/badge/version-0.3.2-0366d6?style=flat-square)](./CHANGELOG.md)
 
 Git graph and Beads issue tools in one VS Code extension.
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "beads-git-graph",
   "displayName": "Beads Git Graph",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Git graph and Beads issue tools for VS Code.",
   "categories": [
     "Other",


### PR DESCRIPTION
## Summary

- Prepare the v0.3.2 stable Marketplace release.

## Changes

- Bump the extension version to 0.3.2.
- Update the README version badge.
- Add v0.3.2 release notes for multi-agent visibility, dependency warnings, Graph scrolling, merge preflight guardrails, and actions/checkout 7.0.0.

## Testing

- pnpm run format:fix
- pnpm run lint
- pnpm run typecheck
- pnpm test
- pnpm run package
- pnpm audit --prod

## Notes

- Marketplace currently has v0.3.1 as the latest stable release; v0.3.2 publishes PR #161 to users.
- bd sync was attempted locally, but this installed bd CLI reports unknown command "sync".