### PR TITLE
fix: add Copilot chat fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Add AI multi-agent cockpit metadata for branch, PR, checks, and sync risk in Beads table, details, and graph views.
 - Report skipped active tasks with reasons when Start Parallel runs.
 - Add a Graph execution map banner and legend for Critical Path, dependency, parent, and merge/worktree risk signals.
+- Copy the agent prompt to the clipboard and open Chat as a fallback when Copilot agent session commands are unavailable.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The Beads view surfaces optional execution hints from issue fields, metadata, or
 - `pr: 123`, `check_status: "success"`, or labels such as `pr:#123`, `checks:success`
 - `sync_risk: "stale"` or label `sync-risk:stale`
 
-When you use **Start AI**, the extension automatically picks the configured or default model, infers SSOT/context from workspace files such as `AGENTS.md`, `.beads/issues.jsonl`, `README.md`, and `docs`, creates or reuses a git worktree for the task, records model/SSOT/worktree/branch metadata, marks the bead in progress, then opens a GitHub Copilot Background Agent chat session with the bead prompt prefilled.
+When you use **Start AI**, the extension automatically picks the configured or default model, infers SSOT/context from workspace files such as `AGENTS.md`, `.beads/issues.jsonl`, `README.md`, and `docs`, creates or reuses a git worktree for the task, records model/SSOT/worktree/branch metadata, marks the bead in progress, then opens a GitHub Copilot Background Agent chat session with the bead prompt prefilled. If VS Code cannot open that session automatically, the prompt is copied to the clipboard and Chat is opened as a fallback.
 
 When multiple ready tasks can run in parallel, **Start Parallel** assigns and starts them in one action. Each task receives its own worktree so the Beads table and graph can show which worktree is expected to carry that agent's changes. Active tasks that are skipped are reported with the reason.
 

--- a/src/beadsView.ts
+++ b/src/beadsView.ts
@@ -55,6 +55,9 @@ const COPILOT_ASSIGN_COMMAND_CANDIDATES = [
   "workbench.action.chat.openSessionWithPrompt.copilotcli",
   "workbench.action.chat.openSessionWithPrompt.copilot-cloud-agent"
 ];
+const CHAT_FALLBACK_COMMAND_CANDIDATES = ["workbench.action.chat.open"];
+
+type AssignAgentOpenResult = "opened" | "copied-prompt" | "failed";
 
 interface GitWorktreeInfo {
   path: string;
@@ -561,7 +564,7 @@ export class BeadsViewProvider implements vscode.WebviewViewProvider, vscode.Dis
     const ssot = this.resolveAssignSsot(workspacePath, issueId, currentSsot);
     const worktree = this.resolveAssignWorktree(workspacePath, issueId, currentWorktree);
 
-    const openedChat = await this.assignAndStartBead({
+    const openResult = await this.assignAndStartBead({
       workspacePath,
       issueId,
       title,
@@ -571,15 +574,22 @@ export class BeadsViewProvider implements vscode.WebviewViewProvider, vscode.Dis
     });
     await this.refresh();
 
-    if (openedChat) {
+    if (openResult === "opened") {
       vscode.window.showInformationMessage(
         `Started ${issueId} with ${model}. Opened Copilot agent session for ${path.basename(worktree)}.`
       );
       return;
     }
 
+    if (openResult === "copied-prompt") {
+      vscode.window.showInformationMessage(
+        `Started ${issueId} with ${model}. Copilot agent prompt copied to clipboard; paste it into Copilot chat.`
+      );
+      return;
+    }
+
     vscode.window.showWarningMessage(
-      `Started ${issueId} with ${model}, but could not open a Copilot agent session automatically.`
+      `Started ${issueId} with ${model}, but could not open Copilot chat or copy the agent prompt.`
     );
   }
 
@@ -657,6 +667,7 @@ export class BeadsViewProvider implements vscode.WebviewViewProvider, vscode.Dis
 
     const uniqueCandidates = [...new Map(candidates.map((item) => [item.issueId, item])).values()];
     let openedCount = 0;
+    let copiedPromptCount = 0;
     for (const candidate of uniqueCandidates) {
       const source = items.find((item) => item.issueId.trim() === candidate.issueId);
       candidate.ssot = this.resolveAssignSsot(workspacePath, candidate.issueId, source?.ssot);
@@ -665,7 +676,7 @@ export class BeadsViewProvider implements vscode.WebviewViewProvider, vscode.Dis
         candidate.issueId,
         source?.worktree
       );
-      const opened = await this.assignAndStartBead({
+      const openResult = await this.assignAndStartBead({
         workspacePath,
         issueId: candidate.issueId,
         title: candidate.title,
@@ -673,15 +684,17 @@ export class BeadsViewProvider implements vscode.WebviewViewProvider, vscode.Dis
         ssot: candidate.ssot,
         worktree: candidate.worktree
       });
-      if (opened) {
+      if (openResult === "opened") {
         openedCount += 1;
+      } else if (openResult === "copied-prompt") {
+        copiedPromptCount += 1;
       }
     }
 
     await this.refresh();
     const skippedSummary = this.formatSkippedParallelTargets(skipped);
     vscode.window.showInformationMessage(
-      `Started ${uniqueCandidates.length} parallel bead(s). Opened ${openedCount} Copilot session(s).${skippedSummary === "" ? "" : ` Skipped ${skippedSummary}.`}`
+      `Started ${uniqueCandidates.length} parallel bead(s). Opened ${openedCount} Copilot session(s). Copied ${copiedPromptCount} prompt(s).${skippedSummary === "" ? "" : ` Skipped ${skippedSummary}.`}`
     );
   }
 
@@ -784,7 +797,7 @@ export class BeadsViewProvider implements vscode.WebviewViewProvider, vscode.Dis
     model: string;
     ssot: string;
     worktree: string | undefined;
-  }) {
+  }): Promise<AssignAgentOpenResult> {
     const commands = new Set(await vscode.commands.getCommands(true));
     const prompt = this.buildAssignAgentPrompt(values);
     const resource = vscode.Uri.file(values.worktree?.trim() || values.workspacePath);
@@ -799,13 +812,29 @@ export class BeadsViewProvider implements vscode.WebviewViewProvider, vscode.Dis
           prompt,
           resource
         });
-        return true;
+        return "opened";
       } catch {
         continue;
       }
     }
 
-    return false;
+    try {
+      await vscode.env.clipboard.writeText(prompt);
+      for (const command of CHAT_FALLBACK_COMMAND_CANDIDATES) {
+        if (!commands.has(command)) {
+          continue;
+        }
+        try {
+          await vscode.commands.executeCommand(command);
+          break;
+        } catch {
+          continue;
+        }
+      }
+      return "copied-prompt";
+    } catch {
+      return "failed";
+    }
   }
 
   private resolveAssignModel(currentModel: string | undefined) {

--- a/tests/beadsWebviewMetadata.test.ts
+++ b/tests/beadsWebviewMetadata.test.ts
@@ -134,6 +134,11 @@ describe("beads webview presentation metadata", () => {
     expect(beadsView).toContain("startParallelBeads");
     expect(beadsView).toContain("formatSkippedParallelTargets");
     expect(beadsView).toContain("workbench.action.chat.openSessionWithPrompt.copilotcli");
+    expect(beadsView).toContain("CHAT_FALLBACK_COMMAND_CANDIDATES");
+    expect(beadsView).toContain("workbench.action.chat.open");
+    expect(beadsView).toContain("vscode.env.clipboard.writeText(prompt)");
+    expect(beadsView).toContain("Copilot agent prompt copied to clipboard");
+    expect(beadsView).toContain("Copied $" + "{copiedPromptCount} prompt(s)");
     expect(beadsView).toContain("vscode.Uri.file(values.worktree?.trim() || values.workspacePath)");
     expect(beadsView).toContain("AGENTS.md");
     expect(beadsView).toContain(".beads/issues.jsonl");


### PR DESCRIPTION
## Summary

- Avoid leaving users stuck when Start AI cannot open a Copilot agent session automatically.
- Fall back to copying the prepared agent prompt and opening Chat when available.

## Changes

- Return explicit open states from the Copilot session opener.
- Copy the generated prompt to the clipboard if Copilot agent session commands are unavailable or fail.
- Try to open the generic VS Code Chat panel after copying the prompt.
- Update Start AI and Start Parallel notifications to report copied prompts.
- Update README, changelog, and presentation metadata tests.

## Testing

- pnpm run format:fix
- pnpm run lint
- pnpm run typecheck
- pnpm test
- pnpm run package

## Notes

- bd sync is not available in this installed bd CLI; bd dolt push was used for Beads state.
- The existing .beads interaction update from the manual Start AI action was not included in this PR commit.