### PR TITLE
fix: keep graph tasks in sync with table

### DIFF
--- a/src/beadsWebview.ts
+++ b/src/beadsWebview.ts
@@ -2,6 +2,7 @@ import * as vscode from "vscode";
 
 import { anonymizeAgentIdentity, buildAgentAliasMap } from "./agentDisplay";
 import {
+  type BeadHierarchyItem,
   type BeadItem,
   beadShortDate,
   beadStatusLabel,
@@ -207,10 +208,11 @@ function buildMergeRiskWarnings(items: BeadItem[]) {
 }
 
 function renderBeadsDependencyGraph(
-  items: BeadItem[],
+  hierarchyItems: BeadHierarchyItem[],
   workspacePath: string,
   agentAliases: ReadonlyMap<string, string>
 ) {
+  const items = hierarchyItems.map((entry) => entry.item);
   const graph = buildBeadDependencyGraph(items);
   const dependencyWarnings = buildDependencyLintWarnings(items);
   const mergeRiskWarnings = buildMergeRiskWarnings(items);
@@ -219,6 +221,7 @@ function renderBeadsDependencyGraph(
   const blockersById = new Map<string, string[]>();
   const blocksById = new Map<string, string[]>();
   const itemsById = new Map(items.map((item) => [item.id, item]));
+  const hierarchyById = new Map(hierarchyItems.map((entry) => [entry.item.id, entry]));
 
   for (const edge of graph.edges) {
     blockersById.set(edge.toId, [...(blockersById.get(edge.toId) ?? []), edge.fromId]);
@@ -281,7 +284,10 @@ function renderBeadsDependencyGraph(
         const mergeRiskWarning = mergeRiskWarnings.get(item.id) ?? "";
         const blockers = (blockersById.get(item.id) ?? []).sort((a, b) => a.localeCompare(b));
         const blocks = (blocksById.get(item.id) ?? []).sort((a, b) => a.localeCompare(b));
-        const parentId = item.parentId.trim();
+        const hierarchyEntry = hierarchyById.get(item.id);
+        const parentId = hierarchyEntry?.parentId ?? item.parentId.trim();
+        const epicId = hierarchyEntry?.epicId ?? "";
+        const depth = hierarchyEntry?.depth ?? 0;
         const dependencyLines = [
           parentId !== "" && itemsById.has(parentId)
             ? `<div class="graphRelation graphParentRelation"><span>Parent</span>${escapeHtml(parentId)}</div>`
@@ -339,7 +345,7 @@ function renderBeadsDependencyGraph(
         ]
           .filter((badge) => badge !== "")
           .join("");
-        return `<div class="graphNode ${node.critical ? "criticalGraphNode" : ""}${dependencyWarning === "" ? "" : " dependencyWarningGraphNode"}${mergeRiskWarning === "" ? "" : " mergeRiskGraphNode"}" data-graph-id="${escapeHtml(item.id)}" data-graph-level="${level}" data-graph-lane="${lane}" data-status="${escapeHtml(normalizedStatus)}" data-critical="${node.critical ? "1" : "0"}" data-parent-id="${escapeHtml(parentId)}" style="--graph-x:${x}px;--graph-y:${y}px"><div class="graphNodeTop"><span class="typeBadge type-${escapeHtml(normalizedType)}">${escapeHtml(item.type)}</span>${node.critical ? '<span class="criticalBadge">Critical path</span>' : ""}</div><div class="beadId">${escapeHtml(item.id)}</div><div class="graphNodeTitle">${escapeHtml(item.title)}</div><div class="graphNodeBadges"><span class="statusBadge status-${escapeHtml(normalizedStatus.replace(/_/g, "-"))}">${escapeHtml(beadStatusLabel(normalizedStatus))}</span><span class="priorityBadge priority-${escapeHtml(normalizedPriority.toLowerCase())}">${escapeHtml(normalizedPriority)}</span>${graphBadges}</div>${dependencyWarning === "" ? "" : `<div class="graphWarning">${escapeHtml(dependencyWarning)}</div>`}${mergeRiskWarning === "" ? "" : `<div class="graphWarning graphMergeRisk">${escapeHtml(mergeRiskWarning)}</div>`}${dependencyLines === "" ? "" : `<div class="graphRelations">${dependencyLines}</div>`}<div class="graphNodeActions">${actionHtml}</div></div>`;
+        return `<div class="graphNode ${node.critical ? "criticalGraphNode" : ""}${dependencyWarning === "" ? "" : " dependencyWarningGraphNode"}${mergeRiskWarning === "" ? "" : " mergeRiskGraphNode"}" data-graph-id="${escapeHtml(item.id)}" data-graph-level="${level}" data-graph-lane="${lane}" data-status="${escapeHtml(normalizedStatus)}" data-critical="${node.critical ? "1" : "0"}" data-parent-id="${escapeHtml(parentId)}" data-epic-id="${escapeHtml(epicId ?? "")}" data-depth="${depth}" style="--graph-x:${x}px;--graph-y:${y}px"><div class="graphNodeTop"><span class="typeBadge type-${escapeHtml(normalizedType)}">${escapeHtml(item.type)}</span>${node.critical ? '<span class="criticalBadge">Critical path</span>' : ""}</div><div class="beadId">${escapeHtml(item.id)}</div><div class="graphNodeTitle">${escapeHtml(item.title)}</div><div class="graphNodeBadges"><span class="statusBadge status-${escapeHtml(normalizedStatus.replace(/_/g, "-"))}">${escapeHtml(beadStatusLabel(normalizedStatus))}</span><span class="priorityBadge priority-${escapeHtml(normalizedPriority.toLowerCase())}">${escapeHtml(normalizedPriority)}</span>${graphBadges}</div>${dependencyWarning === "" ? "" : `<div class="graphWarning">${escapeHtml(dependencyWarning)}</div>`}${mergeRiskWarning === "" ? "" : `<div class="graphWarning graphMergeRisk">${escapeHtml(mergeRiskWarning)}</div>`}${dependencyLines === "" ? "" : `<div class="graphRelations">${dependencyLines}</div>`}<div class="graphNodeActions">${actionHtml}</div></div>`;
       })
       .join("");
   }).join("");
@@ -613,11 +619,7 @@ export function renderBeadsWebviewHtml(
             return `<tr class="${rowClasses}" data-id="${escapeHtml(item.id)}" data-workspace-path="${escapeHtml(group.workspacePath)}" data-parent-id="${escapeHtml(parentId ?? "")}" data-epic-id="${escapeHtml(epicId ?? "")}" data-bead-type="${escapeHtml(normalizedType)}" data-depth="${depth}" data-child-count="${childCount}" data-order-index="${orderIndex}" data-guide-columns="${guideColumns.map((value) => (value ? "1" : "0")).join("")}" data-last-sibling="${isLastSibling ? "1" : "0"}" data-status="${escapeHtml(normalizedStatus)}" data-parallelizable="${item.parallelizable ? "1" : "0"}" data-parallel-source="${escapeHtml(item.parallelizableSource)}" data-item="${escapeHtml(encodeURIComponent(JSON.stringify(serializedItem)))}" data-updated-ts="${updatedTs}" data-type-sort="${typeSortOrder}" data-priority-sort="${Number.isNaN(prioritySortOrder) ? 9 : prioritySortOrder}"><td><span class="typeBadge type-${escapeHtml(normalizedType)}">${escapeHtml(item.type)}</span></td><td class="parallelCell">${parallelCell}</td><td><div class="titleCell" style="--tree-width:${treeWidth}px">${hierarchyToggle}<div class="titleContent"><div class="beadId">${escapeHtml(item.id)}</div><div class="beadTitle">${escapeHtml(item.title)}</div>${executionBadges === "" ? "" : `<div class="beadMeta">${executionBadges}</div>`}</div></div></td><td><div class="statusCell"><span class="statusBadge status-${escapeHtml(normalizedStatus.replace(/_/g, "-"))}">${escapeHtml(statusLabel)}</span>${progressLabel === "" ? "" : `<span class="progressText">${escapeHtml(progressLabel)}</span>`}</div></td><td><span class="priorityBadge priority-${escapeHtml(normalizedPriority.toLowerCase())}">${escapeHtml(normalizedPriority)}</span></td><td class="updatedCell" title="${escapeHtml(item.updatedAt)}">${escapeHtml(shortUpdated)}</td></tr>`;
           })
           .join("");
-        const graphHtml = renderBeadsDependencyGraph(
-          flatItems.map((entry) => entry.item),
-          group.workspacePath,
-          agentAliases
-        );
+        const graphHtml = renderBeadsDependencyGraph(flatItems, group.workspacePath, agentAliases);
         const parallelAction =
           parallelStartTargets.length > 0
             ? `<button class="startParallelBeads workspaceAction" type="button" data-start-parallel-workspace="${escapeHtml(group.workspacePath)}" data-start-parallel-items="${encodeJsonData(parallelStartTargets)}" data-start-parallel-skipped="${encodeJsonData(skippedParallelTargets)}" title="Assign and start all parallel-ready tasks with Copilot${skippedParallelTargets.length > 0 ? `; ${skippedParallelTargets.length} active task(s) skipped with reasons` : ""}">${parallelStartTargets.length} Start Parallel</button>`

--- a/tests/beadsWebviewMetadata.test.ts
+++ b/tests/beadsWebviewMetadata.test.ts
@@ -81,6 +81,8 @@ describe("beads webview presentation metadata", () => {
     expect(beadsWebview).toContain("graphLevelGuide");
     expect(beadsWebview).toContain("graphNodes");
     expect(beadsWebview).toContain("data-graph-lane");
+    expect(beadsWebview).toContain("data-epic-id");
+    expect(beadsWebview).toContain("data-depth");
     expect(beadsWebview).toContain("--graph-x");
     expect(beadsWebview).toContain("--graph-height");
     expect(beadsWebview).toContain("dependencyArrowHead");
@@ -106,6 +108,9 @@ describe("beads webview presentation metadata", () => {
       "worktree: normalizeOptionalDatasetValue(button.dataset.assignStartWorktree)"
     );
     expect(beadsMain).toContain("renderDependencyGraphOverlays");
+    expect(beadsMain).toContain("visibleRowIds");
+    expect(beadsMain).toContain('section.querySelectorAll<BeadRow>("tbody .beadRow")');
+    expect(beadsMain).toContain("visibleRowIds.has(node.dataset.graphId");
     expect(beadsMain).toContain('querySelectorAll<HTMLElement>(".graphPane")');
     expect(beadsMain).toContain('pane.addEventListener("scroll"');
     expect(beadsMain).toContain('command: "assignStartBead"');

--- a/web/beadsMain.ts
+++ b/web/beadsMain.ts
@@ -711,9 +711,17 @@ function renderHierarchyOverlays() {
 }
 
 function refreshGraphNodeVisibility() {
-  for (const node of Array.from(document.querySelectorAll<HTMLElement>(".graphNode"))) {
-    const status = (node.dataset.status || "") as StatusFilter;
-    node.style.display = activeFilters.has(status) ? "" : "none";
+  for (const section of Array.from(document.querySelectorAll<BeadSection>("section"))) {
+    const visibleRowIds = new Set(
+      Array.from(section.querySelectorAll<BeadRow>("tbody .beadRow"))
+        .filter((row) => row.style.display !== "none")
+        .map((row) => row.dataset.id || "")
+        .filter((id) => id !== "")
+    );
+
+    for (const node of Array.from(section.querySelectorAll<HTMLElement>(".graphNode"))) {
+      node.style.display = visibleRowIds.has(node.dataset.graphId || "") ? "" : "none";
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

- Keep Graph view task visibility aligned with the visible Beads table rows.

## Changes

- Pass hierarchy entries into the Graph renderer so graph nodes carry the same parent, epic, and depth metadata as table rows.
- Make Graph node visibility use the actual visible table row IDs per workspace section.
- Add presentation metadata tests for Graph/Table parity.

## Testing

- pnpm run format:fix
- pnpm run lint
- pnpm run typecheck
- pnpm test
- pnpm run package

## Notes

- pnpm run package required running outside the sandbox because pnpm needed to write to the user cache.
- bd sync is not available in this installed bd CLI; bd dolt push was used where applicable.