### PR TITLE
fix: stabilize beads graph view

### DIFF
--- a/src/beadsView.ts
+++ b/src/beadsView.ts
@@ -81,9 +81,11 @@ interface PullRequestMergeCheck {
 
 export class BeadsViewProvider implements vscode.WebviewViewProvider, vscode.Disposable {
   public static readonly viewType = "beads-git-graph.beadsView";
+  private static readonly refreshDebounceMs = 250;
 
   private webviewView: vscode.WebviewView | null = null;
   private panel: vscode.WebviewPanel | null = null;
+  private refreshTimer: NodeJS.Timeout | null = null;
   private readonly disposables: vscode.Disposable[] = [];
   private readonly panelDisposables: vscode.Disposable[] = [];
   private readonly viewDisposables: vscode.Disposable[] = [];
@@ -144,6 +146,10 @@ export class BeadsViewProvider implements vscode.WebviewViewProvider, vscode.Dis
   }
 
   public dispose() {
+    if (this.refreshTimer !== null) {
+      clearTimeout(this.refreshTimer);
+      this.refreshTimer = null;
+    }
     for (const workspacePath of this.branchWatchers.keys()) {
       this.stopWatchingBranch(workspacePath);
     }
@@ -172,8 +178,6 @@ export class BeadsViewProvider implements vscode.WebviewViewProvider, vscode.Dis
     );
 
     void this.showPanel();
-
-    void this.refresh();
   }
 
   public showPanel(column?: vscode.ViewColumn) {
@@ -238,6 +242,10 @@ export class BeadsViewProvider implements vscode.WebviewViewProvider, vscode.Dis
   }
 
   public async refresh() {
+    if (this.refreshTimer !== null) {
+      clearTimeout(this.refreshTimer);
+      this.refreshTimer = null;
+    }
     if (this.webviewView === null && this.panel === null) {
       return;
     }
@@ -253,7 +261,17 @@ export class BeadsViewProvider implements vscode.WebviewViewProvider, vscode.Dis
 
   private handleBeadsFilesChanged() {
     void this.syncBranchWatchers();
-    void this.refresh();
+    this.scheduleRefresh();
+  }
+
+  private scheduleRefresh() {
+    if (this.refreshTimer !== null) {
+      clearTimeout(this.refreshTimer);
+    }
+    this.refreshTimer = setTimeout(() => {
+      this.refreshTimer = null;
+      void this.refresh();
+    }, BeadsViewProvider.refreshDebounceMs);
   }
 
   private async loadBeads(): Promise<BeadLoadResult> {

--- a/src/beadsWebview.ts
+++ b/src/beadsWebview.ts
@@ -385,12 +385,14 @@ function renderBeadsDependencyGraph(
       : `<div class="graphPathStrip emptyCriticalPath"><span>Critical Path</span><strong>No dependency path yet</strong></div>`;
   const graphLegendHtml =
     '<div class="graphLegend"><span class="dependencyLegend">Dependency</span><span class="criticalLegend">Critical path</span><span class="parentLegend">Parent</span><span class="riskLegend">Merge/worktree risk</span></div>';
+  const graphControlsHtml =
+    '<div class="graphControls" aria-label="Graph zoom controls"><button class="graphZoomButton" type="button" data-graph-zoom-action="out" title="Zoom out" aria-label="Zoom out">-</button><span class="graphZoomValue" data-graph-zoom-value>100%</span><button class="graphZoomButton" type="button" data-graph-zoom-action="in" title="Zoom in" aria-label="Zoom in">+</button><button class="graphZoomButton graphZoomReset" type="button" data-graph-zoom-action="reset" title="Reset zoom" aria-label="Reset zoom">1:1</button></div>';
   const graphIssuesHtml =
     dependencyWarningHtml === "" && mergeRiskHtml === ""
       ? ""
       : `<div class="graphIssueStack">${dependencyWarningHtml}${mergeRiskHtml}</div>`;
 
-  return `<div class="graphPane" data-workspace-path="${escapeHtml(workspacePath)}"><div class="graphHeader"><div class="workspaceName">Execution Map</div><div class="workspaceSummary"><span class="summaryPill">${graph.edges.length} deps</span>${criticalSummary}${dependencyWarningSummary}${mergeRiskSummary}</div></div>${graphIssuesHtml}<div class="graphMapFrame"><div class="graphMapHeader">${criticalPathHtml}${graphLegendHtml}</div><div class="graphCanvas" style="--graph-width:${graphWidth}px;--graph-height:${graphHeight}px;--graph-node-width:${GRAPH_NODE_WIDTH}px">${edgeHtml}<svg class="dependencyOverlay" aria-hidden="true"></svg>${levelGuideHtml}<div class="graphNodes">${nodeHtml}</div></div></div></div>`;
+  return `<div class="graphPane" data-workspace-path="${escapeHtml(workspacePath)}"><div class="graphHeader"><div class="workspaceName">Execution Map</div><div class="workspaceSummary"><span class="summaryPill">${graph.edges.length} deps</span>${criticalSummary}${dependencyWarningSummary}${mergeRiskSummary}</div></div>${graphIssuesHtml}<div class="graphMapFrame"><div class="graphMapHeader"><div class="graphMapHeaderMain">${criticalPathHtml}${graphLegendHtml}</div>${graphControlsHtml}</div><div class="graphScroller"><div class="graphCanvas" data-graph-width="${graphWidth}" data-graph-height="${graphHeight}" style="width:${graphWidth}px;height:${graphHeight}px"><div class="graphContent" style="width:${graphWidth}px;height:${graphHeight}px;--graph-node-width:${GRAPH_NODE_WIDTH}px">${edgeHtml}<svg class="dependencyOverlay" aria-hidden="true"></svg>${levelGuideHtml}<div class="graphNodes">${nodeHtml}</div></div></div></div></div></div>`;
 }
 
 export function renderBeadsWebviewHtml(
@@ -809,7 +811,7 @@ th:nth-child(1){width:52px;}th:nth-child(2){width:72px;}th:nth-child(4){width:78
 .detailsGrid .key{opacity:.78;font-size:11px;}
 .detailsGrid div:nth-child(2n){min-width:0;overflow-wrap:anywhere;}
 .detailsDescription{margin-top:8px;padding-top:8px;border-top:1px solid var(--vscode-panel-border);white-space:pre-wrap;line-height:1.45;}
-.graphPane{position:relative;border:1px solid var(--vscode-panel-border);border-radius:8px;background:var(--vscode-editor-background);overflow:auto;padding:0;max-height:calc(100vh - 132px);min-height:360px;}
+.graphPane{position:relative;display:flex;flex-direction:column;border:1px solid var(--vscode-panel-border);border-radius:8px;background:var(--vscode-editor-background);overflow:hidden;padding:0;max-height:calc(100vh - 132px);min-height:360px;}
 .graphHeader{display:flex;align-items:center;justify-content:space-between;gap:8px;margin:0;position:sticky;top:0;left:0;z-index:5;background:var(--vscode-editor-background);padding:10px 12px 8px;border-bottom:1px solid var(--vscode-panel-border);}
 .criticalSummary{border-color:rgba(236,72,153,.5);color:var(--vscode-charts-pink,#ec4899);}
 .dependencyWarningSummary{border-color:rgba(245,158,11,.55);color:var(--vscode-editorWarning-foreground,#f59e0b);}
@@ -824,8 +826,9 @@ th:nth-child(1){width:52px;}th:nth-child(2){width:72px;}th:nth-child(4){width:78
 .graphIssueDrawer summary strong{display:inline-flex;align-items:center;min-height:18px;padding:1px 7px;border-radius:999px;border:1px solid currentColor;font-size:10px;}
 .dependencyIssueDrawer summary{color:var(--vscode-editorWarning-foreground,#f59e0b);}
 .mergeRiskIssueDrawer summary{color:var(--vscode-errorForeground,#ef4444);}
-.graphMapFrame{margin:10px 12px 12px;border:1px solid var(--vscode-panel-border);border-radius:8px;background:var(--vscode-sideBar-background,var(--vscode-editor-background));min-width:max-content;overflow:hidden;}
+.graphMapFrame{display:flex;flex:1 1 auto;flex-direction:column;min-height:0;margin:10px 12px 12px;border:1px solid var(--vscode-panel-border);border-radius:8px;background:var(--vscode-sideBar-background,var(--vscode-editor-background));overflow:hidden;}
 .graphMapHeader{display:grid;grid-template-columns:minmax(280px,1fr) auto;align-items:center;gap:10px;padding:8px 10px;border-bottom:1px solid var(--vscode-panel-border);background:rgba(128,128,128,.06);}
+.graphMapHeaderMain{display:grid;gap:6px;min-width:0;}
 .graphPathStrip{display:grid;grid-template-columns:auto minmax(0,1fr);align-items:center;gap:8px;min-width:0;}
 .graphPathStrip span{font-size:10px;font-weight:800;text-transform:uppercase;color:var(--vscode-charts-pink,#ec4899);letter-spacing:0;}
 .graphPathStrip strong{font-size:11px;line-height:1.35;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}
@@ -839,11 +842,17 @@ th:nth-child(1){width:52px;}th:nth-child(2){width:72px;}th:nth-child(4){width:78
 .parentLegend{color:var(--vscode-textLink-foreground,#3b82f6)!important;}
 .parentLegend::before{border-top-style:dashed!important;}
 .riskLegend{color:var(--vscode-errorForeground,#ef4444)!important;}
+.graphControls{display:flex;align-items:center;gap:4px;white-space:nowrap;}
+.graphZoomButton{display:inline-flex;align-items:center;justify-content:center;min-width:26px;height:24px;padding:0 7px;border-radius:6px;font-size:12px;font-weight:800;line-height:1;}
+.graphZoomReset{font-size:10px;}
+.graphZoomValue{min-width:42px;text-align:center;font-size:11px;font-weight:750;color:var(--vscode-descriptionForeground);}
 .graphWarningBand{display:flex;flex-wrap:wrap;gap:4px;margin:0;padding:0 8px 8px;max-height:92px;overflow:auto;}
 .graphWarningBand span{display:inline-flex;align-items:center;min-height:18px;padding:1px 6px;border-radius:6px;border:1px solid rgba(245,158,11,.5);background:rgba(245,158,11,.12);color:var(--vscode-editorWarning-foreground,#f59e0b);font-size:10px;font-weight:650;}
 .graphRiskBand{display:flex;flex-wrap:wrap;gap:4px;margin:0;padding:0 8px 8px;max-height:92px;overflow:auto;}
 .graphRiskBand span{display:inline-flex;align-items:center;min-height:18px;padding:1px 6px;border-radius:6px;border:1px solid rgba(239,68,68,.5);background:rgba(239,68,68,.12);color:var(--vscode-errorForeground,#ef4444);font-size:10px;font-weight:650;}
-.graphCanvas{position:relative;width:max(100%, var(--graph-width, 960px));height:max(620px, var(--graph-height, 620px));background-color:var(--vscode-editor-background);background-image:linear-gradient(rgba(128,128,128,.1) 1px, transparent 1px),linear-gradient(90deg, rgba(128,128,128,.1) 1px, transparent 1px);background-size:48px 48px;}
+.graphScroller{flex:1 1 auto;min-height:0;overflow:auto;overscroll-behavior:contain;background:var(--vscode-editor-background);}
+.graphCanvas{position:relative;min-width:100%;min-height:620px;background-color:var(--vscode-editor-background);background-image:linear-gradient(rgba(128,128,128,.1) 1px, transparent 1px),linear-gradient(90deg, rgba(128,128,128,.1) 1px, transparent 1px);background-size:48px 48px;}
+.graphContent{position:absolute;left:0;top:0;transform:scale(var(--graph-zoom,1));transform-origin:0 0;}
 .dependencyOverlay{position:absolute;inset:0;z-index:1;width:100%;height:100%;pointer-events:none;overflow:visible;}
 .dependencyPath{fill:none;stroke:rgba(148,163,184,.8);stroke-width:1.6;stroke-linecap:round;stroke-linejoin:round;vector-effect:non-scaling-stroke;}
 .dependencyPath.criticalDependencyPath{stroke:var(--vscode-charts-pink,#ec4899);stroke-width:2.8;}
@@ -903,8 +912,9 @@ th:nth-child(1){width:52px;}th:nth-child(2){width:72px;}th:nth-child(4){width:78
   .graphIssueStack{padding:8px 0 0;}
   .graphMapFrame{margin:8px 0 0;}
   .graphMapHeader{grid-template-columns:1fr;align-items:start;}
+  .graphControls{justify-content:flex-start;}
   .graphLegend{justify-content:flex-start;}
-  .graphCanvas{height:max(560px, var(--graph-height, 560px));}
+  .graphCanvas{min-height:560px;}
 }
 code{font-family:var(--vscode-editor-font-family);}
 </style>

--- a/tests/beadsWebviewMetadata.test.ts
+++ b/tests/beadsWebviewMetadata.test.ts
@@ -47,9 +47,16 @@ describe("beads webview presentation metadata", () => {
     expect(beadsWebview).toContain("graphPathStrip");
     expect(beadsWebview).toContain("graphMapFrame");
     expect(beadsWebview).toContain("graphMapHeader");
+    expect(beadsWebview).toContain("graphMapHeaderMain");
     expect(beadsWebview).toContain("No dependency path yet");
     expect(beadsWebview).toContain("graphIssueDrawer");
     expect(beadsWebview).toContain("graphIssueStack");
+    expect(beadsWebview).toContain("graphControls");
+    expect(beadsWebview).toContain("data-graph-zoom-action");
+    expect(beadsWebview).toContain("graphScroller");
+    expect(beadsWebview).toContain("graphContent");
+    expect(beadsWebview).toContain("data-graph-width");
+    expect(beadsWebview).toContain("data-graph-height");
     expect(beadsWebview).toContain("graphLegend");
     expect(beadsWebview).toContain("dependencyLegend");
     expect(beadsWebview).toContain("criticalLegend");
@@ -91,14 +98,20 @@ describe("beads webview presentation metadata", () => {
     expect(beadsWebview).toContain("data-epic-id");
     expect(beadsWebview).toContain("data-depth");
     expect(beadsWebview).toContain("--graph-x");
-    expect(beadsWebview).toContain("--graph-height");
     expect(beadsWebview).toContain("dependencyArrowHead");
     expect(beadsWebview).not.toContain("graphGrid");
     expect(beadsWebview).not.toContain("graphStage");
     expect(beadsMain).toContain("getState(): BeadsWebviewState | undefined");
     expect(beadsMain).toContain("setState(state: BeadsWebviewState): void");
     expect(beadsMain).toContain("normalizeViewMode(vscode.getState()?.viewMode)");
+    expect(beadsMain).toContain("normalizeGraphZoom(vscode.getState()?.graphZoom)");
     expect(beadsMain).toContain("saveViewMode(mode)");
+    expect(beadsMain).toContain("saveWebviewState");
+    expect(beadsMain).toContain("saveGraphScroll");
+    expect(beadsMain).toContain("restoreGraphScroll");
+    expect(beadsMain).toContain("setGraphZoom");
+    expect(beadsMain).toContain("GRAPH_ZOOM_MIN");
+    expect(beadsMain).toContain("GRAPH_ZOOM_MAX");
     expect(beadsMain).toContain("normalizeOptionalDatasetValue");
     expect(beadsMain).toContain("marker-end");
     expect(beadsMain).toContain("criticalDependencyArrow");
@@ -119,7 +132,10 @@ describe("beads webview presentation metadata", () => {
     expect(beadsMain).toContain('section.querySelectorAll<BeadRow>("tbody .beadRow")');
     expect(beadsMain).toContain("visibleRowIds.has(node.dataset.graphId");
     expect(beadsMain).toContain('querySelectorAll<HTMLElement>(".graphPane")');
-    expect(beadsMain).toContain('pane.addEventListener("scroll"');
+    expect(beadsMain).toContain('querySelector<HTMLElement>(".graphScroller")');
+    expect(beadsMain).toContain('getGraphScroller(pane)?.addEventListener("scroll"');
+    expect(beadsMain).toContain("content.style.setProperty");
+    expect(beadsMain).toContain("data-graph-zoom-action");
     expect(beadsMain).toContain('command: "assignStartBead"');
     expect(beadsMain).toContain('command: "startParallelBeads"');
     expect(beadsMain).toContain("detailsCell.colSpan = 6");
@@ -129,6 +145,9 @@ describe("beads webview presentation metadata", () => {
   });
 
   it("starts AI work with automatic model, SSOT, and worktree context", () => {
+    expect(beadsView).toContain("refreshDebounceMs");
+    expect(beadsView).toContain("refreshTimer");
+    expect(beadsView).toContain("scheduleRefresh");
     expect(beadsView).toContain("DEFAULT_ASSIGN_MODEL");
     expect(beadsView).toContain("resolveAssignModel");
     expect(beadsView).toContain("resolveAssignSsot");

--- a/web/beadsMain.ts
+++ b/web/beadsMain.ts
@@ -12,8 +12,11 @@ type StatusFilter = "open" | "in_progress" | "blocked" | "closed" | "other";
 type ViewMode = "table" | "graph";
 type BeadRow = HTMLTableRowElement & { dataset: DOMStringMap };
 type BeadSection = HTMLElement & { dataset: DOMStringMap };
+type GraphScrollState = { left: number; top: number };
 type BeadsWebviewState = {
   viewMode?: ViewMode;
+  graphZoom?: number;
+  graphScroll?: Record<string, GraphScrollState>;
   [key: string]: unknown;
 };
 
@@ -60,6 +63,9 @@ const STATUS_LABELS: Record<StatusFilter, string> = {
   other: "Other"
 };
 const ALL_FILTERS: StatusFilter[] = ["open", "in_progress", "blocked", "closed", "other"];
+const GRAPH_ZOOM_MIN = 0.6;
+const GRAPH_ZOOM_MAX = 1.8;
+const GRAPH_ZOOM_STEP = 0.1;
 const PRESET_FILTERS: Record<string, StatusFilter[]> = {
   default: ["open", "in_progress", "blocked"],
   open: ["open"],
@@ -76,6 +82,7 @@ let contextMenuRow: BeadRow | null = null;
 let contextMenuWorkspacePath = "";
 let sortState: { key: SortKey; desc: boolean } = { key: "updated", desc: true };
 let activeViewMode: ViewMode = normalizeViewMode(vscode.getState()?.viewMode);
+let graphZoom = normalizeGraphZoom(vscode.getState()?.graphZoom);
 let rowClickTimer: number | null = null;
 const collapsedIds = new Set<string>();
 const collapsedEpicIds = new Set<string>();
@@ -111,11 +118,20 @@ function normalizeViewMode(value: unknown): ViewMode {
   return value === "graph" ? "graph" : "table";
 }
 
-function saveViewMode(mode: ViewMode) {
+function normalizeGraphZoom(value: unknown) {
+  const numericValue = typeof value === "number" && Number.isFinite(value) ? value : 1;
+  return Math.min(GRAPH_ZOOM_MAX, Math.max(GRAPH_ZOOM_MIN, numericValue));
+}
+
+function saveWebviewState(patch: Partial<BeadsWebviewState>) {
   vscode.setState({
     ...vscode.getState(),
-    viewMode: mode
+    ...patch
   });
+}
+
+function saveViewMode(mode: ViewMode) {
+  saveWebviewState({ viewMode: mode });
 }
 
 function normalizeOptionalDatasetValue(value: string | undefined) {
@@ -487,6 +503,10 @@ function applyViewMode(mode: ViewMode) {
   graphViewButton.classList.toggle("active", mode === "graph");
   tableViewButton.setAttribute("aria-pressed", mode === "table" ? "true" : "false");
   graphViewButton.setAttribute("aria-pressed", mode === "graph" ? "true" : "false");
+  if (mode === "graph") {
+    applyGraphZoomToAll();
+    restoreGraphScroll();
+  }
   renderHierarchyOverlays();
   renderDependencyGraphOverlays();
 }
@@ -725,13 +745,135 @@ function refreshGraphNodeVisibility() {
   }
 }
 
+function getGraphScroller(pane: HTMLElement) {
+  return pane.querySelector<HTMLElement>(".graphScroller");
+}
+
+function getGraphCanvas(pane: HTMLElement) {
+  return pane.querySelector<HTMLElement>(".graphCanvas");
+}
+
+function getGraphContent(pane: HTMLElement) {
+  return pane.querySelector<HTMLElement>(".graphContent");
+}
+
+function getGraphWorkspaceKey(pane: HTMLElement) {
+  return pane.dataset.workspacePath || "default";
+}
+
+function getGraphBaseSize(canvas: HTMLElement) {
+  return {
+    width: Math.max(1, parseFloat(canvas.dataset.graphWidth || "960")),
+    height: Math.max(1, parseFloat(canvas.dataset.graphHeight || "620"))
+  };
+}
+
+function saveGraphZoom() {
+  saveWebviewState({ graphZoom });
+}
+
+function saveGraphScroll(pane: HTMLElement) {
+  const scroller = getGraphScroller(pane);
+  if (scroller === null) {
+    return;
+  }
+  const state = vscode.getState() ?? {};
+  const graphScroll = { ...state.graphScroll };
+  graphScroll[getGraphWorkspaceKey(pane)] = {
+    left: scroller.scrollLeft,
+    top: scroller.scrollTop
+  };
+  saveWebviewState({ graphScroll });
+}
+
+function updateGraphZoomLabels() {
+  const label = `${Math.round(graphZoom * 100)}%`;
+  for (const element of Array.from(
+    document.querySelectorAll<HTMLElement>("[data-graph-zoom-value]")
+  )) {
+    element.textContent = label;
+  }
+}
+
+function applyGraphZoomToPane(pane: HTMLElement) {
+  const scroller = getGraphScroller(pane);
+  const canvas = getGraphCanvas(pane);
+  const content = getGraphContent(pane);
+  if (scroller === null || canvas === null || content === null) {
+    return;
+  }
+
+  const base = getGraphBaseSize(canvas);
+  canvas.style.width = `${Math.max(scroller.clientWidth, base.width * graphZoom)}px`;
+  canvas.style.height = `${Math.max(scroller.clientHeight, base.height * graphZoom)}px`;
+  content.style.setProperty("--graph-zoom", graphZoom.toFixed(2));
+}
+
+function applyGraphZoomToAll() {
+  for (const pane of Array.from(document.querySelectorAll<HTMLElement>(".graphPane"))) {
+    applyGraphZoomToPane(pane);
+  }
+  updateGraphZoomLabels();
+}
+
+function restoreGraphScroll() {
+  const graphScroll = vscode.getState()?.graphScroll ?? {};
+  window.requestAnimationFrame(() => {
+    for (const pane of Array.from(document.querySelectorAll<HTMLElement>(".graphPane"))) {
+      const scroller = getGraphScroller(pane);
+      const saved = graphScroll[getGraphWorkspaceKey(pane)];
+      if (scroller === null || saved === undefined) {
+        continue;
+      }
+      scroller.scrollLeft = Math.max(0, saved.left);
+      scroller.scrollTop = Math.max(0, saved.top);
+    }
+    renderDependencyGraphOverlays();
+  });
+}
+
+function setGraphZoom(nextZoom: number) {
+  const previousZoom = graphZoom;
+  const nextNormalizedZoom = normalizeGraphZoom(nextZoom);
+  if (Math.abs(previousZoom - nextNormalizedZoom) < 0.001) {
+    return;
+  }
+
+  const centers = new Map<HTMLElement, { x: number; y: number }>();
+  for (const pane of Array.from(document.querySelectorAll<HTMLElement>(".graphPane"))) {
+    const scroller = getGraphScroller(pane);
+    if (scroller === null) {
+      continue;
+    }
+    centers.set(pane, {
+      x: (scroller.scrollLeft + scroller.clientWidth / 2) / previousZoom,
+      y: (scroller.scrollTop + scroller.clientHeight / 2) / previousZoom
+    });
+  }
+
+  graphZoom = nextNormalizedZoom;
+  applyGraphZoomToAll();
+  for (const [pane, center] of centers.entries()) {
+    const scroller = getGraphScroller(pane);
+    if (scroller === null) {
+      continue;
+    }
+    scroller.scrollLeft = Math.max(0, center.x * graphZoom - scroller.clientWidth / 2);
+    scroller.scrollTop = Math.max(0, center.y * graphZoom - scroller.clientHeight / 2);
+    saveGraphScroll(pane);
+  }
+  saveGraphZoom();
+  renderDependencyGraphOverlays();
+}
+
 function renderDependencyGraphOverlays() {
   for (const [paneIndex, pane] of Array.from(
     document.querySelectorAll<HTMLElement>(".graphPane")
   ).entries()) {
     const overlay = pane.querySelector<SVGElement>(".dependencyOverlay");
     const canvas = pane.querySelector<HTMLElement>(".graphCanvas");
-    if (overlay === null || canvas === null) {
+    const content = getGraphContent(pane);
+    if (overlay === null || canvas === null || content === null) {
       continue;
     }
     if (activeViewMode !== "graph" || pane.offsetParent === null) {
@@ -739,9 +881,11 @@ function renderDependencyGraphOverlays() {
       continue;
     }
 
-    const canvasRect = canvas.getBoundingClientRect();
-    const width = Math.max(1, Math.round(canvas.scrollWidth));
-    const height = Math.max(1, Math.round(canvas.scrollHeight));
+    applyGraphZoomToPane(pane);
+
+    const contentRect = content.getBoundingClientRect();
+    const width = Math.max(1, Math.round(content.offsetWidth));
+    const height = Math.max(1, Math.round(content.offsetHeight));
     overlay.setAttribute("viewBox", `0 0 ${width} ${height}`);
     overlay.style.width = `${width}px`;
     overlay.style.height = `${height}px`;
@@ -764,10 +908,10 @@ function renderDependencyGraphOverlays() {
 
       const fromRect = fromNode.getBoundingClientRect();
       const toRect = toNode.getBoundingClientRect();
-      const x1 = fromRect.right - canvasRect.left;
-      const y1 = fromRect.top - canvasRect.top + fromRect.height / 2;
-      const x2 = toRect.left - canvasRect.left;
-      const y2 = toRect.top - canvasRect.top + toRect.height / 2;
+      const x1 = (fromRect.right - contentRect.left) / graphZoom;
+      const y1 = (fromRect.top - contentRect.top + fromRect.height / 2) / graphZoom;
+      const x2 = (toRect.left - contentRect.left) / graphZoom;
+      const y2 = (toRect.top - contentRect.top + toRect.height / 2) / graphZoom;
       const gap = Math.max(28, Math.abs(x2 - x1) * 0.45);
       const d =
         x2 >= x1
@@ -849,12 +993,28 @@ closeBeadAction.addEventListener("click", () => {
   vscode.postMessage({ command: "closeBead", issueId, workspacePath, title: item.title || "" });
 });
 window.addEventListener("resize", () => {
+  applyGraphZoomToAll();
   renderHierarchyOverlays();
   renderDependencyGraphOverlays();
 });
 for (const pane of Array.from(document.querySelectorAll<HTMLElement>(".graphPane"))) {
-  pane.addEventListener("scroll", () => {
+  getGraphScroller(pane)?.addEventListener("scroll", () => {
+    saveGraphScroll(pane);
     renderDependencyGraphOverlays();
+  });
+}
+for (const button of Array.from(
+  document.querySelectorAll<HTMLButtonElement>("[data-graph-zoom-action]")
+)) {
+  button.addEventListener("click", () => {
+    const action = button.dataset.graphZoomAction || "";
+    if (action === "in") {
+      setGraphZoom(graphZoom + GRAPH_ZOOM_STEP);
+    } else if (action === "out") {
+      setGraphZoom(graphZoom - GRAPH_ZOOM_STEP);
+    } else if (action === "reset") {
+      setGraphZoom(1);
+    }
   });
 }
 queryElement<HTMLButtonElement>("#refresh").addEventListener("click", () => {
@@ -1026,6 +1186,8 @@ for (const row of Array.from(document.querySelectorAll<BeadRow>("tbody tr.beadRo
 }
 
 renderFilterChips();
+applyGraphZoomToAll();
 applyViewMode(activeViewMode);
 applySort();
 applyFilters();
+restoreGraphScroll();


### PR DESCRIPTION
## Summary

- Stabilize the Beads Graph view during refreshes and make large graphs navigable.

## Changes

- Debounce Beads file watcher refreshes and remove an immediate duplicate refresh on webview resolution.
- Save and restore Graph scroll position through VS Code webview state.
- Add Graph zoom controls with persisted zoom state.
- Move Graph content into a dedicated X/Y scroller so the Graph header stays stable.
- Update presentation metadata tests for Graph zoom and scroll state.

## Testing

- ./node_modules/.bin/oxfmt .
- ./node_modules/.bin/oxlint
- ./node_modules/.bin/tsc -p ./src --noEmit
- ./node_modules/.bin/tsc -p ./web --noEmit
- ./node_modules/.bin/vitest run
- Direct esbuild compile for src/extension.ts, web/main.ts, and web/beadsMain.ts

## Notes

- pnpm run commands attempted to refresh node_modules and hit the local pnpm build-script policy for esbuild. The same formatter, lint, typecheck, test, and compile binaries were run directly from node_modules.
- VSIX packaging was not completed locally because vsce invokes npm run vscode:prepublish, which re-enters the same pnpm policy path.
- bd sync is not available in this installed bd CLI; bd dolt push was used where applicable.