### PR TITLE
fix: handle graph start ai clicks

### DIFF
--- a/src/beadsWebview.ts
+++ b/src/beadsWebview.ts
@@ -877,7 +877,7 @@ th:nth-child(1){width:52px;}th:nth-child(2){width:72px;}th:nth-child(4){width:78
 .graphRelation{display:grid;grid-template-columns:54px minmax(0,1fr);gap:5px;font-size:10px;color:var(--vscode-descriptionForeground);line-height:1.35;}
 .graphRelation span{font-weight:700;color:var(--vscode-foreground);}
 .graphParentRelation{border-left:2px dashed var(--vscode-textLink-foreground,#3b82f6);padding-left:5px;}
-.graphNodeActions{display:flex;justify-content:flex-end;margin-top:8px;}
+.graphNodeActions{position:relative;z-index:3;display:flex;justify-content:flex-end;margin-top:8px;}
 .assignStartBead,.mergeParallelPrs{height:24px;padding:0 8px;font-weight:650;}
 .mergeParallelPrs{border-color:rgba(249,115,22,.55);background:rgba(249,115,22,.16);color:var(--vscode-charts-orange,#f97316);}
 .assignStartBead:disabled{opacity:.45;cursor:default;}

--- a/tests/beadsWebviewMetadata.test.ts
+++ b/tests/beadsWebviewMetadata.test.ts
@@ -113,6 +113,8 @@ describe("beads webview presentation metadata", () => {
     expect(beadsMain).toContain("GRAPH_ZOOM_MIN");
     expect(beadsMain).toContain("GRAPH_ZOOM_MAX");
     expect(beadsMain).toContain("normalizeOptionalDatasetValue");
+    expect(beadsMain).toContain("postAssignStartBead");
+    expect(beadsMain).toContain('target.closest(".assignStartBead")');
     expect(beadsMain).toContain("marker-end");
     expect(beadsMain).toContain("criticalDependencyArrow");
     expect(beadsMain).toContain(

--- a/web/beadsMain.ts
+++ b/web/beadsMain.ts
@@ -189,6 +189,24 @@ function closeContextMenu() {
   contextMenuWorkspacePath = "";
 }
 
+function postAssignStartBead(button: HTMLButtonElement) {
+  const issueId = button.dataset.assignStartId || "";
+  const workspacePath = button.dataset.assignStartWorkspace || "";
+  if (!bdAvailable || issueId === "" || workspacePath === "") {
+    return;
+  }
+  vscode.postMessage({
+    command: "assignStartBead",
+    issueId,
+    workspacePath,
+    title: button.dataset.assignStartTitle || "",
+    agent: normalizeOptionalDatasetValue(button.dataset.assignStartAgent),
+    model: normalizeOptionalDatasetValue(button.dataset.assignStartModel),
+    ssot: normalizeOptionalDatasetValue(button.dataset.assignStartSsot),
+    worktree: normalizeOptionalDatasetValue(button.dataset.assignStartWorktree)
+  });
+}
+
 function openContextMenu(row: BeadRow | null, workspacePath: string, event: MouseEvent) {
   contextMenuRow = row;
   contextMenuWorkspacePath = workspacePath;
@@ -945,6 +963,12 @@ document.addEventListener("click", (event) => {
   if (!(target instanceof Element)) {
     return;
   }
+  const assignStartButton = target.closest(".assignStartBead") as HTMLButtonElement | null;
+  if (assignStartButton !== null) {
+    event.preventDefault();
+    postAssignStartBead(assignStartButton);
+    return;
+  }
   if (!target.closest(".menu")) {
     filterMenu.classList.remove("open");
   }
@@ -1066,25 +1090,6 @@ for (const button of Array.from(
       workspacePath,
       items,
       skipped: skipped ?? []
-    });
-  });
-}
-for (const button of Array.from(document.querySelectorAll<HTMLButtonElement>(".assignStartBead"))) {
-  button.addEventListener("click", () => {
-    const issueId = button.dataset.assignStartId || "";
-    const workspacePath = button.dataset.assignStartWorkspace || "";
-    if (!bdAvailable || issueId === "" || workspacePath === "") {
-      return;
-    }
-    vscode.postMessage({
-      command: "assignStartBead",
-      issueId,
-      workspacePath,
-      title: button.dataset.assignStartTitle || "",
-      agent: normalizeOptionalDatasetValue(button.dataset.assignStartAgent),
-      model: normalizeOptionalDatasetValue(button.dataset.assignStartModel),
-      ssot: normalizeOptionalDatasetValue(button.dataset.assignStartSsot),
-      worktree: normalizeOptionalDatasetValue(button.dataset.assignStartWorktree)
     });
   });
 }


### PR DESCRIPTION
## Summary

- Fix Graph view Start AI clicks by routing the button through a delegated webview click handler.

## Changes

- Extract Start AI message posting into a shared helper.
- Handle assignStartBead clicks through document-level delegation so Graph/Table buttons remain active after view changes.
- Raise Graph node action controls above the dependency overlay.
- Add metadata test coverage for the delegated handler.

## Testing

- ./node_modules/.bin/oxfmt .
- ./node_modules/.bin/oxlint
- ./node_modules/.bin/tsc -p ./src --noEmit
- ./node_modules/.bin/tsc -p ./web --noEmit
- ./node_modules/.bin/vitest run
- ./node_modules/.bin/esbuild --bundle src/extension.ts --outfile=out/extension.js --platform=node --format=cjs --target=es6 --external:vscode --minify
- ./node_modules/.bin/esbuild --bundle web/main.ts --outfile=out/web.min.js --minify --target=es6 --format=iife
- ./node_modules/.bin/esbuild --bundle web/beadsMain.ts --outfile=out/beadsWebview.min.js --minify --target=es6 --format=iife

## Notes

- bd sync is not available in the installed bd CLI, so bd dolt push was used successfully.
