### PR TITLE
fix: stabilize beads graph view state

### DIFF
--- a/src/beadsView.ts
+++ b/src/beadsView.ts
@@ -172,12 +172,12 @@ export class BeadsViewProvider implements vscode.WebviewViewProvider, vscode.Dis
       }),
       webviewView.onDidChangeVisibility(() => {
         if (webviewView.visible) {
-          this.showPanel();
+          void this.refresh();
         }
       })
     );
 
-    void this.showPanel();
+    void this.refresh();
   }
 
   public showPanel(column?: vscode.ViewColumn) {

--- a/src/beadsWebview.ts
+++ b/src/beadsWebview.ts
@@ -701,6 +701,7 @@ body{font-family:var(--vscode-font-family);color:var(--vscode-foreground);paddin
 .contextMenu button:disabled{opacity:.45;cursor:default;}
 button{border:1px solid var(--vscode-button-border,transparent);background:var(--vscode-button-background);color:var(--vscode-button-foreground);padding:4px 8px;cursor:pointer;border-radius:6px;font-size:11px;}
 button:hover{background:var(--vscode-button-hoverBackground);}
+#clearFilters{display:none;}
 .actionBtn{display:inline-flex;align-items:center;justify-content:center;height:24px;padding:0 10px;border-radius:6px;background:rgba(128,128,128,.1);border:1px solid rgba(128,128,128,.5);gap:6px;transition:border-color .18s ease, background-color .18s ease, box-shadow .18s ease;}
 .actionBtn:hover{background:rgba(128,128,128,.2);}
 #syncBeads{min-width:68px;}
@@ -811,7 +812,7 @@ th:nth-child(1){width:52px;}th:nth-child(2){width:72px;}th:nth-child(4){width:78
 .detailsGrid .key{opacity:.78;font-size:11px;}
 .detailsGrid div:nth-child(2n){min-width:0;overflow-wrap:anywhere;}
 .detailsDescription{margin-top:8px;padding-top:8px;border-top:1px solid var(--vscode-panel-border);white-space:pre-wrap;line-height:1.45;}
-.graphPane{position:relative;display:flex;flex-direction:column;border:1px solid var(--vscode-panel-border);border-radius:8px;background:var(--vscode-editor-background);overflow:hidden;padding:0;max-height:calc(100vh - 132px);min-height:360px;}
+.graphPane{position:relative;display:flex;flex-direction:column;height:clamp(360px,calc(100vh - 132px),900px);border:1px solid var(--vscode-panel-border);border-radius:8px;background:var(--vscode-editor-background);overflow:hidden;padding:0;}
 .graphHeader{display:flex;align-items:center;justify-content:space-between;gap:8px;margin:0;position:sticky;top:0;left:0;z-index:5;background:var(--vscode-editor-background);padding:10px 12px 8px;border-bottom:1px solid var(--vscode-panel-border);}
 .criticalSummary{border-color:rgba(236,72,153,.5);color:var(--vscode-charts-pink,#ec4899);}
 .dependencyWarningSummary{border-color:rgba(245,158,11,.55);color:var(--vscode-editorWarning-foreground,#f59e0b);}
@@ -907,7 +908,7 @@ th:nth-child(1){width:52px;}th:nth-child(2){width:72px;}th:nth-child(4){width:78
   .inlineDetailsRow{display:block;}
   .inlineDetailsRow td{display:block;padding:0 6px 8px;}
   .detailsGrid{grid-template-columns:82px minmax(0,1fr);}
-  .graphPane{max-height:calc(100vh - 118px);min-height:320px;padding:8px;}
+  .graphPane{height:clamp(320px,calc(100vh - 118px),820px);padding:8px;}
   .graphHeader{position:relative;padding:8px;margin:-8px -8px 0;}
   .graphIssueStack{padding:8px 0 0;}
   .graphMapFrame{margin:8px 0 0;}

--- a/tests/beadsWebviewMetadata.test.ts
+++ b/tests/beadsWebviewMetadata.test.ts
@@ -88,7 +88,9 @@ describe("beads webview presentation metadata", () => {
     expect(beadsWebview).toContain("graphParentRelation");
     expect(beadsWebview).toContain("buildMergeRiskWarnings");
     expect(beadsWebview).toContain("buildDependencyLintWarnings");
-    expect(beadsWebview).toContain("max-height:calc(100vh - 132px)");
+    expect(beadsWebview).toContain("height:clamp(360px,calc(100vh - 132px),900px)");
+    expect(beadsWebview).toContain("#clearFilters{display:none;}");
+    expect(beadsMain).toContain("getGraphRequiredSize");
     expect(beadsWebview).toContain("graphLevelGuide");
     expect(beadsWebview).toContain("graphLevelLabel");
     expect(beadsWebview).toContain("No blockers");

--- a/web/beadsMain.ts
+++ b/web/beadsMain.ts
@@ -786,6 +786,19 @@ function getGraphBaseSize(canvas: HTMLElement) {
   };
 }
 
+function getGraphRequiredSize(pane: HTMLElement, base: { width: number; height: number }) {
+  let width = base.width;
+  let height = base.height;
+  for (const node of Array.from(pane.querySelectorAll<HTMLElement>(".graphNode"))) {
+    if (node.style.display === "none") {
+      continue;
+    }
+    width = Math.max(width, node.offsetLeft + node.offsetWidth + 40);
+    height = Math.max(height, node.offsetTop + node.offsetHeight + 40);
+  }
+  return { width, height };
+}
+
 function saveGraphZoom() {
   saveWebviewState({ graphZoom });
 }
@@ -821,7 +834,9 @@ function applyGraphZoomToPane(pane: HTMLElement) {
     return;
   }
 
-  const base = getGraphBaseSize(canvas);
+  const base = getGraphRequiredSize(pane, getGraphBaseSize(canvas));
+  content.style.width = `${base.width}px`;
+  content.style.height = `${base.height}px`;
   canvas.style.width = `${Math.max(scroller.clientWidth, base.width * graphZoom)}px`;
   canvas.style.height = `${Math.max(scroller.clientHeight, base.height * graphZoom)}px`;
   content.style.setProperty("--graph-zoom", graphZoom.toFixed(2));


### PR DESCRIPTION
## Summary

- Fix Beads view flicker and Graph vertical scrolling.

## Changes

- Stop revealing the Beads panel automatically when the sidebar Beads view becomes visible.
- Hide the Clear filter button by default so it does not flash during webview hydration.
- Give the Graph pane a stable viewport height.
- Resize the Graph canvas from measured node bounds so tall nodes can scroll vertically.
- Update metadata coverage for the Graph sizing and Clear button behavior.

## Testing

- ./node_modules/.bin/oxfmt .
- ./node_modules/.bin/oxlint
- ./node_modules/.bin/tsc -p ./src --noEmit
- ./node_modules/.bin/tsc -p ./web --noEmit
- ./node_modules/.bin/vitest run
- ./node_modules/.bin/esbuild --bundle src/extension.ts --outfile=out/extension.js --platform=node --format=cjs --target=es6 --external:vscode --minify
- ./node_modules/.bin/esbuild --bundle web/main.ts --outfile=out/web.min.js --minify --target=es6 --format=iife
- ./node_modules/.bin/esbuild --bundle web/beadsMain.ts --outfile=out/beadsWebview.min.js --minify --target=es6 --format=iife

## Notes

- bd sync is not available in the installed bd CLI, so bd dolt push was used successfully.
