### PR TITLE
fix: keep marketplace stable downloads current

### DIFF
--- a/.github/workflows/daily-prerelease.yml
+++ b/.github/workflows/daily-prerelease.yml
@@ -172,7 +172,8 @@ jobs:
         run: pnpm dlx ovsx -p "$OPEN_VSX_TOKEN" publish -i "${{ steps.locate_vsix.outputs.vsix_path }}" --skip-duplicate
 
       - name: Publish daily prerelease to VS Marketplace
-        if: env.HAS_UNRELEASED_COMMITS == 'true' && env.VS_MARKETPLACE_TOKEN != ''
+        # Keep VS Marketplace downloads on stable releases; re-enable only if pre-release becomes opt-in in the Marketplace UI.
+        if: false
         run: pnpm dlx @vscode/vsce publish --packagePath "${{ steps.locate_vsix.outputs.vsix_path }}" --skip-duplicate --pre-release -p "$VS_MARKETPLACE_TOKEN"
 
       - name: Upload VSIX artifact

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+## [0.4.20260702] - 2026-07-02
+
+### Changed
+
+- Promote the stable Marketplace release above the daily pre-release version so the normal download path resolves to the fixed Beads view build.
+- Stop publishing daily pre-releases to VS Marketplace to keep stable releases as the default Marketplace download.
+
 ## [0.3.4] - 2026-07-02
 
 ### Fixed
@@ -337,7 +344,8 @@
 
 Initial release
 
-[Unreleased]: https://github.com/ToppyMicroServices/beads-git-graph/compare/v0.3.4...HEAD
+[Unreleased]: https://github.com/ToppyMicroServices/beads-git-graph/compare/v0.4.20260702...HEAD
+[0.4.20260702]: https://github.com/ToppyMicroServices/beads-git-graph/compare/v0.3.4...v0.4.20260702
 [0.3.4]: https://github.com/ToppyMicroServices/beads-git-graph/compare/v0.3.3...v0.3.4
 [0.3.3]: https://github.com/ToppyMicroServices/beads-git-graph/compare/v0.3.2...v0.3.3
 [0.3.2]: https://github.com/ToppyMicroServices/beads-git-graph/compare/v0.3.1...v0.3.2

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Beads Git Graph
 
 [![MIT License](https://img.shields.io/badge/license-MIT-2ea44f?style=flat-square)](./LICENSE)
-[![Version 0.3.4](https://img.shields.io/badge/version-0.3.4-0366d6?style=flat-square)](./CHANGELOG.md)
+[![Version 0.4.20260702](https://img.shields.io/badge/version-0.4.20260702-0366d6?style=flat-square)](./CHANGELOG.md)
 
 Git graph and Beads issue tools in one VS Code extension.
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "beads-git-graph",
   "displayName": "Beads Git Graph",
-  "version": "0.3.4",
+  "version": "0.4.20260702",
   "description": "Git graph and Beads issue tools for VS Code.",
   "categories": [
     "Other",


### PR DESCRIPTION
## Summary

- Keep the VS Marketplace normal download path on the stable Beads build.

## Changes

- Bump the stable extension version to 0.4.20260702 so it outranks the existing daily pre-release version.
- Add release notes explaining the Marketplace download promotion.
- Update the README version badge.
- Stop daily pre-release publishing to VS Marketplace so future daily builds do not replace the stable download path.

## Testing

- ./node_modules/.bin/oxfmt .
- ./node_modules/.bin/oxlint
- ./node_modules/.bin/tsc -p ./src --noEmit
- ./node_modules/.bin/tsc -p ./web --noEmit
- ./node_modules/.bin/vitest run
- ./node_modules/.bin/esbuild --bundle src/extension.ts --outfile=out/extension.js --platform=node --format=cjs --target=es6 --external:vscode --minify
- ./node_modules/.bin/esbuild --bundle web/main.ts --outfile=out/web.min.js --minify --target=es6 --format=iife
- ./node_modules/.bin/esbuild --bundle web/beadsMain.ts --outfile=out/beadsWebview.min.js --minify --target=es6 --format=iife

## Notes

- VS Marketplace serves version-specific 0.3.4 downloads, but the normal latest download path was resolving to daily pre-release 0.4.20260701.
- bd sync is not available in the installed bd CLI, so bd dolt push was used successfully.
