### PR TITLE
fix: stabilize Beads graph refresh

### DIFF
--- a/src/beadsView.ts
+++ b/src/beadsView.ts
@@ -85,6 +85,8 @@ export class BeadsViewProvider implements vscode.WebviewViewProvider, vscode.Dis
 
   private webviewView: vscode.WebviewView | null = null;
   private panel: vscode.WebviewPanel | null = null;
+  private webviewViewRenderSignature = "";
+  private panelRenderSignature = "";
   private refreshTimer: NodeJS.Timeout | null = null;
   private readonly disposables: vscode.Disposable[] = [];
   private readonly panelDisposables: vscode.Disposable[] = [];
@@ -113,7 +115,6 @@ export class BeadsViewProvider implements vscode.WebviewViewProvider, vscode.Dis
       }
     );
     this.watchers = [
-      vscode.workspace.createFileSystemWatcher("**/.beads/beads.db*"),
       vscode.workspace.createFileSystemWatcher("**/.beads/config.yaml"),
       vscode.workspace.createFileSystemWatcher("**/.beads/metadata.json"),
       vscode.workspace.createFileSystemWatcher("**/.beads/*.json"),
@@ -157,6 +158,8 @@ export class BeadsViewProvider implements vscode.WebviewViewProvider, vscode.Dis
     this.disposeScoped(this.panelDisposables);
     this.webviewView = null;
     this.panel = null;
+    this.webviewViewRenderSignature = "";
+    this.panelRenderSignature = "";
     while (this.disposables.length > 0) {
       this.disposables.pop()?.dispose();
     }
@@ -165,15 +168,11 @@ export class BeadsViewProvider implements vscode.WebviewViewProvider, vscode.Dis
   public resolveWebviewView(webviewView: vscode.WebviewView) {
     this.disposeScoped(this.viewDisposables);
     this.webviewView = webviewView;
+    this.webviewViewRenderSignature = "";
     webviewView.webview.options = { enableScripts: true };
     this.viewDisposables.push(
       webviewView.webview.onDidReceiveMessage((message) => {
         void this.handleMessage(message);
-      }),
-      webviewView.onDidChangeVisibility(() => {
-        if (webviewView.visible) {
-          void this.refresh();
-        }
       })
     );
 
@@ -187,7 +186,6 @@ export class BeadsViewProvider implements vscode.WebviewViewProvider, vscode.Dis
 
     if (this.panel) {
       this.panel.reveal(targetColumn);
-      void this.refresh();
       return;
     }
 
@@ -213,12 +211,8 @@ export class BeadsViewProvider implements vscode.WebviewViewProvider, vscode.Dis
       }),
       this.panel.onDidDispose(() => {
         this.panel = null;
+        this.panelRenderSignature = "";
         this.disposeScoped(this.panelDisposables);
-      }),
-      this.panel.onDidChangeViewState(() => {
-        if (this.panel?.visible) {
-          void this.refresh();
-        }
       })
     );
     void this.refresh();
@@ -251,12 +245,39 @@ export class BeadsViewProvider implements vscode.WebviewViewProvider, vscode.Dis
     }
 
     const results = await this.loadBeads();
+    const signature = this.getRenderSignature(results);
     if (this.webviewView !== null) {
-      this.webviewView.webview.html = this.getHtml(this.webviewView.webview, results);
+      this.refreshWebviewHtml("view", this.webviewView.webview, results, signature);
     }
     if (this.panel !== null) {
-      this.panel.webview.html = this.getHtml(this.panel.webview, results);
+      this.refreshWebviewHtml("panel", this.panel.webview, results, signature);
     }
+  }
+
+  private getRenderSignature(result: BeadLoadResult) {
+    return JSON.stringify(result);
+  }
+
+  private refreshWebviewHtml(
+    target: "view" | "panel",
+    webview: vscode.Webview,
+    result: BeadLoadResult,
+    signature: string
+  ) {
+    if (target === "view") {
+      if (this.webviewViewRenderSignature === signature) {
+        return;
+      }
+      webview.html = this.getHtml(webview, result);
+      this.webviewViewRenderSignature = signature;
+      return;
+    }
+
+    if (this.panelRenderSignature === signature) {
+      return;
+    }
+    webview.html = this.getHtml(webview, result);
+    this.panelRenderSignature = signature;
   }
 
   private handleBeadsFilesChanged() {

--- a/tests/beadsWebviewMetadata.test.ts
+++ b/tests/beadsWebviewMetadata.test.ts
@@ -191,6 +191,18 @@ describe("beads webview presentation metadata", () => {
     expect(beadsView).not.toContain("Assign AI Model");
   });
 
+  it("avoids redundant Beads webview reloads", () => {
+    expect(beadsView).not.toContain('createFileSystemWatcher("**/.beads/beads.db*")');
+    expect(beadsView).toContain("webviewViewRenderSignature");
+    expect(beadsView).toContain("panelRenderSignature");
+    expect(beadsView).toContain("getRenderSignature");
+    expect(beadsView).toContain("refreshWebviewHtml");
+    expect(beadsView).toContain("this.webviewViewRenderSignature === signature");
+    expect(beadsView).toContain("this.panelRenderSignature === signature");
+    expect(beadsView).not.toContain("onDidChangeVisibility");
+    expect(beadsView).not.toContain("onDidChangeViewState");
+  });
+
   it("anonymizes email-like agent identities in display labels", () => {
     expect(beadsWebview).toContain("buildAgentAliasMap");
     expect(beadsWebview).toContain("anonymizeAgentIdentity");


### PR DESCRIPTION
## Summary

- Reduce unnecessary Beads webview reloads that reset Graph scroll state.

## Changes

- Stop watching noisy .beads SQLite database files for refresh triggers.
- Avoid refreshing the Beads webview on visibility or panel reveal events.
- Skip replacing webview HTML when the loaded Beads data has not changed.
- Add regression coverage for redundant reload prevention.

## Testing

- ./node_modules/.bin/oxfmt .
- ./node_modules/.bin/oxlint
- ./node_modules/.bin/tsc -p ./src --noEmit
- ./node_modules/.bin/tsc -p ./web --noEmit
- ./node_modules/.bin/vitest run
- ./node_modules/.bin/esbuild --bundle src/extension.ts --outfile=out/extension.js --platform=node --format=cjs --target=es6 --external:vscode --minify
- ./node_modules/.bin/esbuild --bundle web/main.ts --outfile=out/web.min.js --minify --target=es6 --format=iife
- ./node_modules/.bin/esbuild --bundle web/beadsMain.ts --outfile=out/beadsWebview.min.js --minify --target=es6 --format=iife

## Notes

- bd sync is unavailable in the installed bd CLI; bd dolt push was run instead.