### PR TITLE
fix: compact Beads graph layout

### DIFF
--- a/src/beadsWebview.ts
+++ b/src/beadsWebview.ts
@@ -16,12 +16,12 @@ import { type BeadLoadResult } from "./beadsViewTypes";
 import { escapeHtml, getNonce } from "./utils";
 
 const BEADS_WEBVIEW_SCRIPT = "beadsWebview.min.js";
-const GRAPH_NODE_WIDTH = 280;
-const GRAPH_NODE_HEIGHT_ESTIMATE = 150;
-const GRAPH_LEVEL_GAP = 96;
-const GRAPH_LANE_GAP = 54;
-const GRAPH_PADDING_X = 44;
-const GRAPH_PADDING_Y = 56;
+const GRAPH_NODE_WIDTH = 252;
+const GRAPH_NODE_HEIGHT_ESTIMATE = 140;
+const GRAPH_LEVEL_GAP = 56;
+const GRAPH_LANE_GAP = 30;
+const GRAPH_PADDING_X = 28;
+const GRAPH_PADDING_Y = 44;
 
 function getRawAssigneeLabel(item: BeadItem) {
   return item.assignee.trim() !== "" && item.assignee !== "-" ? item.assignee.trim() : "";
@@ -863,8 +863,8 @@ th:nth-child(1){width:52px;}th:nth-child(2){width:72px;}th:nth-child(4){width:78
 .graphCanvas{position:relative;min-width:100%;min-height:620px;background-color:var(--vscode-editor-background);background-image:linear-gradient(rgba(128,128,128,.1) 1px, transparent 1px),linear-gradient(90deg, rgba(128,128,128,.1) 1px, transparent 1px);background-size:48px 48px;}
 .graphContent{position:absolute;left:0;top:0;transform:scale(var(--graph-zoom,1));transform-origin:0 0;}
 .dependencyOverlay{position:absolute;inset:0;z-index:1;width:100%;height:100%;pointer-events:none;overflow:visible;}
-.dependencyPath{fill:none;stroke:rgba(148,163,184,.8);stroke-width:1.6;stroke-linecap:round;stroke-linejoin:round;vector-effect:non-scaling-stroke;}
-.dependencyPath.criticalDependencyPath{stroke:var(--vscode-charts-pink,#ec4899);stroke-width:2.8;}
+.dependencyPath{fill:none;stroke:rgba(148,163,184,.8);stroke-width:1.4;stroke-linecap:round;stroke-linejoin:round;vector-effect:non-scaling-stroke;}
+.dependencyPath.criticalDependencyPath{stroke:var(--vscode-charts-pink,#ec4899);stroke-width:2;}
 .dependencyArrowHead{fill:rgba(148,163,184,.88);}
 .criticalDependencyArrowHead{fill:var(--vscode-charts-pink,#ec4899);}
 .graphLevelGuide{position:absolute;top:0;bottom:18px;left:var(--graph-guide-x);z-index:0;border-left:1px dashed rgba(128,128,128,.28);}

--- a/tests/beadsWebviewMetadata.test.ts
+++ b/tests/beadsWebviewMetadata.test.ts
@@ -105,6 +105,10 @@ describe("beads webview presentation metadata", () => {
     expect(beadsWebview).toContain("data-depth");
     expect(beadsWebview).toContain("--graph-x");
     expect(beadsWebview).toContain("dependencyArrowHead");
+    expect(beadsWebview).toContain("const GRAPH_NODE_WIDTH = 252");
+    expect(beadsWebview).toContain("const GRAPH_LEVEL_GAP = 56");
+    expect(beadsWebview).toContain("const GRAPH_LANE_GAP = 30");
+    expect(beadsWebview).toContain("stroke-width:2;");
     expect(beadsWebview).not.toContain("graphGrid");
     expect(beadsWebview).not.toContain("graphStage");
     expect(beadsMain).toContain("getState(): BeadsWebviewState | undefined");
@@ -123,6 +127,8 @@ describe("beads webview presentation metadata", () => {
     expect(beadsMain).toContain('target.closest(".assignStartBead")');
     expect(beadsMain).toContain("marker-end");
     expect(beadsMain).toContain("criticalDependencyArrow");
+    expect(beadsMain).toContain('markerWidth="6.5"');
+    expect(beadsMain).toContain("Math.max(18, Math.abs(x2 - x1) * 0.34)");
     expect(beadsMain).toContain(
       "agent: normalizeOptionalDatasetValue(button.dataset.assignStartAgent)"
     );

--- a/web/beadsMain.ts
+++ b/web/beadsMain.ts
@@ -930,7 +930,7 @@ function renderDependencyGraphOverlays() {
     );
     const markerId = `dependencyArrow-${paneIndex}`;
     const criticalMarkerId = `criticalDependencyArrow-${paneIndex}`;
-    const markerDefs = `<defs><marker id="${markerId}" viewBox="0 0 10 10" refX="8.5" refY="5" markerWidth="8" markerHeight="8" orient="auto"><path class="dependencyArrowHead" d="M0 0 L10 5 L0 10 Z" /></marker><marker id="${criticalMarkerId}" viewBox="0 0 10 10" refX="8.5" refY="5" markerWidth="9" markerHeight="9" orient="auto"><path class="criticalDependencyArrowHead" d="M0 0 L10 5 L0 10 Z" /></marker></defs>`;
+    const markerDefs = `<defs><marker id="${markerId}" viewBox="0 0 10 10" refX="8.5" refY="5" markerWidth="6" markerHeight="6" orient="auto"><path class="dependencyArrowHead" d="M0 0 L10 5 L0 10 Z" /></marker><marker id="${criticalMarkerId}" viewBox="0 0 10 10" refX="8.5" refY="5" markerWidth="6.5" markerHeight="6.5" orient="auto"><path class="criticalDependencyArrowHead" d="M0 0 L10 5 L0 10 Z" /></marker></defs>`;
     let paths = "";
     for (const edge of Array.from(pane.querySelectorAll<HTMLElement>(".graphEdge"))) {
       const fromNode = nodesById.get(edge.dataset.fromId || "");
@@ -945,7 +945,7 @@ function renderDependencyGraphOverlays() {
       const y1 = (fromRect.top - contentRect.top + fromRect.height / 2) / graphZoom;
       const x2 = (toRect.left - contentRect.left) / graphZoom;
       const y2 = (toRect.top - contentRect.top + toRect.height / 2) / graphZoom;
-      const gap = Math.max(28, Math.abs(x2 - x1) * 0.45);
+      const gap = Math.max(18, Math.abs(x2 - x1) * 0.34);
       const d =
         x2 >= x1
           ? `M${x1.toFixed(1)} ${y1.toFixed(1)} C${(x1 + gap).toFixed(1)} ${y1.toFixed(1)} ${(x2 - gap).toFixed(1)} ${y2.toFixed(1)} ${x2.toFixed(1)} ${y2.toFixed(1)}`


### PR DESCRIPTION
## Summary

- Make the Beads Graph view fit more tasks on screen and reduce oversized critical path arrows.

## Changes

- Reduce graph node width, level gap, lane gap, and graph padding.
- Reduce dependency and critical path stroke widths.
- Reduce SVG arrow marker sizes and curve control gap.
- Add regression coverage for compact graph layout values.

## Testing

- ./node_modules/.bin/oxfmt .
- ./node_modules/.bin/oxlint
- ./node_modules/.bin/tsc -p ./src --noEmit
- ./node_modules/.bin/tsc -p ./web --noEmit
- ./node_modules/.bin/vitest run
- ./node_modules/.bin/esbuild --bundle src/extension.ts --outfile=out/extension.js --platform=node --format=cjs --target=es6 --external:vscode --minify
- ./node_modules/.bin/esbuild --bundle web/main.ts --outfile=out/web.min.js --minify --target=es6 --format=iife
- ./node_modules/.bin/esbuild --bundle web/beadsMain.ts --outfile=out/beadsWebview.min.js --minify --target=es6 --format=iife

## Notes

- bd sync is unavailable in the installed bd CLI; bd dolt push was run instead.