### PR TITLE
chore: prepare v0.4.20260706 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+## [0.4.20260706] - 2026-07-06
+
+### Fixed
+
+- Keep the Beads Graph view from reloading when the underlying Beads data has not changed.
+- Reduce noisy Beads database file refresh triggers that reset Graph scroll state.
+- Compact the Graph layout so task nodes and dependency arrows fit better on screen.
+- Reduce critical path arrow and stroke size.
+
 ## [0.4.20260703] - 2026-07-03
 
 ### Fixed
@@ -351,7 +360,8 @@
 
 Initial release
 
-[Unreleased]: https://github.com/ToppyMicroServices/beads-git-graph/compare/v0.4.20260703...HEAD
+[Unreleased]: https://github.com/ToppyMicroServices/beads-git-graph/compare/v0.4.20260706...HEAD
+[0.4.20260706]: https://github.com/ToppyMicroServices/beads-git-graph/compare/v0.4.20260703...v0.4.20260706
 [0.4.20260703]: https://github.com/ToppyMicroServices/beads-git-graph/compare/v0.4.20260702...v0.4.20260703
 [0.4.20260702]: https://github.com/ToppyMicroServices/beads-git-graph/compare/v0.3.4...v0.4.20260702
 [0.3.4]: https://github.com/ToppyMicroServices/beads-git-graph/compare/v0.3.3...v0.3.4

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Beads Git Graph
 
 [![MIT License](https://img.shields.io/badge/license-MIT-2ea44f?style=flat-square)](./LICENSE)
-[![Version 0.4.20260703](https://img.shields.io/badge/version-0.4.20260703-0366d6?style=flat-square)](./CHANGELOG.md)
+[![Version 0.4.20260706](https://img.shields.io/badge/version-0.4.20260706-0366d6?style=flat-square)](./CHANGELOG.md)
 
 Git graph and Beads issue tools in one VS Code extension.
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "beads-git-graph",
   "displayName": "Beads Git Graph",
-  "version": "0.4.20260703",
+  "version": "0.4.20260706",
   "description": "Git graph and Beads issue tools for VS Code.",
   "categories": [
     "Other",


### PR DESCRIPTION
## Summary

- Prepare the v0.4.20260706 release for the Beads Graph refresh and layout fixes.

## Changes

- Bump extension version to 0.4.20260706.
- Update the README version badge.
- Add v0.4.20260706 changelog entries and compare links.

## Testing

- ./node_modules/.bin/oxfmt .
- ./node_modules/.bin/oxlint
- ./node_modules/.bin/tsc -p ./src --noEmit
- ./node_modules/.bin/tsc -p ./web --noEmit
- ./node_modules/.bin/vitest run
- ./node_modules/.bin/esbuild --bundle src/extension.ts --outfile=out/extension.js --platform=node --format=cjs --target=es6 --external:vscode --minify
- ./node_modules/.bin/esbuild --bundle web/main.ts --outfile=out/web.min.js --minify --target=es6 --format=iife
- ./node_modules/.bin/esbuild --bundle web/beadsMain.ts --outfile=out/beadsWebview.min.js --minify --target=es6 --format=iife
- CI=true corepack pnpm install --frozen-lockfile
- CI=true corepack pnpm run package
- unzip -p beads-git-graph-0.4.20260706.vsix extension/package.json | rg -n '"name"|"publisher"|"version"'

## Notes

- bd sync is unavailable in the installed bd CLI; bd dolt push was run instead.
- Bare pnpm 11.7.0 fails local package checks because this repo pins pnpm 10.29.3 through packageManager. The workflow-compatible corepack pnpm path passed.