### PR TITLE
fix: fit Beads graph with wheel zoom

### DIFF
--- a/src/beadsWebview.ts
+++ b/src/beadsWebview.ts
@@ -390,14 +390,12 @@ function renderBeadsDependencyGraph(
       : `<div class="graphPathStrip emptyCriticalPath"><span>Critical Path</span><strong>No dependency path yet</strong></div>`;
   const graphLegendHtml =
     '<div class="graphLegend"><span class="dependencyLegend">Dependency</span><span class="criticalLegend">Critical path</span><span class="parentLegend">Parent</span><span class="riskLegend">Merge/worktree risk</span></div>';
-  const graphControlsHtml =
-    '<div class="graphControls" aria-label="Graph zoom controls"><button class="graphZoomButton" type="button" data-graph-zoom-action="out" title="Zoom out" aria-label="Zoom out">-</button><span class="graphZoomValue" data-graph-zoom-value>100%</span><button class="graphZoomButton" type="button" data-graph-zoom-action="in" title="Zoom in" aria-label="Zoom in">+</button><button class="graphZoomButton graphZoomReset" type="button" data-graph-zoom-action="reset" title="Reset zoom" aria-label="Reset zoom">1:1</button></div>';
   const graphIssuesHtml =
     dependencyWarningHtml === "" && mergeRiskHtml === ""
       ? ""
       : `<div class="graphIssueStack">${dependencyWarningHtml}${mergeRiskHtml}</div>`;
 
-  return `<div class="graphPane" data-workspace-path="${escapeHtml(workspacePath)}"><div class="graphHeader"><div class="workspaceName">Execution Map</div><div class="workspaceSummary"><span class="summaryPill">${graph.edges.length} deps</span>${criticalSummary}${dependencyWarningSummary}${mergeRiskSummary}</div></div>${graphIssuesHtml}<div class="graphMapFrame"><div class="graphMapHeader"><div class="graphMapHeaderMain">${criticalPathHtml}${graphLegendHtml}</div>${graphControlsHtml}</div><div class="graphScroller"><div class="graphCanvas" data-graph-width="${graphWidth}" data-graph-height="${graphHeight}" style="width:${graphWidth}px;height:${graphHeight}px"><div class="graphContent" style="width:${graphWidth}px;height:${graphHeight}px;--graph-node-width:${GRAPH_NODE_WIDTH}px">${edgeHtml}<svg class="dependencyOverlay" aria-hidden="true"></svg>${levelGuideHtml}<div class="graphNodes">${nodeHtml}</div></div></div></div></div></div>`;
+  return `<div class="graphPane" data-workspace-path="${escapeHtml(workspacePath)}"><div class="graphHeader"><div class="workspaceName">Execution Map</div><div class="workspaceSummary"><span class="summaryPill">${graph.edges.length} deps</span>${criticalSummary}${dependencyWarningSummary}${mergeRiskSummary}</div></div>${graphIssuesHtml}<div class="graphMapFrame"><div class="graphMapHeader"><div class="graphMapHeaderMain">${criticalPathHtml}${graphLegendHtml}</div></div><div class="graphScroller"><div class="graphCanvas" data-graph-width="${graphWidth}" data-graph-height="${graphHeight}" style="width:${graphWidth}px;height:${graphHeight}px"><div class="graphContent" style="width:${graphWidth}px;height:${graphHeight}px;--graph-node-width:${GRAPH_NODE_WIDTH}px">${edgeHtml}<svg class="dependencyOverlay" aria-hidden="true"></svg>${levelGuideHtml}<div class="graphNodes">${nodeHtml}</div></div></div></div></div></div>`;
 }
 
 export function renderBeadsWebviewHtml(
@@ -836,7 +834,7 @@ th:nth-child(1){width:52px;}th:nth-child(2){width:72px;}th:nth-child(4){width:78
 .dependencyIssueDrawer summary{color:var(--vscode-editorWarning-foreground,#f59e0b);}
 .mergeRiskIssueDrawer summary{color:var(--vscode-errorForeground,#ef4444);}
 .graphMapFrame{display:flex;flex:1 1 auto;flex-direction:column;min-height:0;margin:10px 12px 12px;border:1px solid var(--vscode-panel-border);border-radius:8px;background:var(--vscode-sideBar-background,var(--vscode-editor-background));overflow:hidden;}
-.graphMapHeader{display:grid;grid-template-columns:minmax(280px,1fr) auto;align-items:center;gap:10px;padding:8px 10px;border-bottom:1px solid var(--vscode-panel-border);background:rgba(128,128,128,.06);}
+.graphMapHeader{display:grid;grid-template-columns:1fr;align-items:center;gap:10px;padding:8px 10px;border-bottom:1px solid var(--vscode-panel-border);background:rgba(128,128,128,.06);}
 .graphMapHeaderMain{display:grid;gap:6px;min-width:0;}
 .graphPathStrip{display:grid;grid-template-columns:auto minmax(0,1fr);align-items:center;gap:8px;min-width:0;}
 .graphPathStrip span{font-size:10px;font-weight:800;text-transform:uppercase;color:var(--vscode-charts-pink,#ec4899);letter-spacing:0;}
@@ -851,16 +849,12 @@ th:nth-child(1){width:52px;}th:nth-child(2){width:72px;}th:nth-child(4){width:78
 .parentLegend{color:var(--vscode-textLink-foreground,#3b82f6)!important;}
 .parentLegend::before{border-top-style:dashed!important;}
 .riskLegend{color:var(--vscode-errorForeground,#ef4444)!important;}
-.graphControls{display:flex;align-items:center;gap:4px;white-space:nowrap;}
-.graphZoomButton{display:inline-flex;align-items:center;justify-content:center;min-width:26px;height:24px;padding:0 7px;border-radius:6px;font-size:12px;font-weight:800;line-height:1;}
-.graphZoomReset{font-size:10px;}
-.graphZoomValue{min-width:42px;text-align:center;font-size:11px;font-weight:750;color:var(--vscode-descriptionForeground);}
 .graphWarningBand{display:flex;flex-wrap:wrap;gap:4px;margin:0;padding:0 8px 8px;max-height:92px;overflow:auto;}
 .graphWarningBand span{display:inline-flex;align-items:center;min-height:18px;padding:1px 6px;border-radius:6px;border:1px solid rgba(245,158,11,.5);background:rgba(245,158,11,.12);color:var(--vscode-editorWarning-foreground,#f59e0b);font-size:10px;font-weight:650;}
 .graphRiskBand{display:flex;flex-wrap:wrap;gap:4px;margin:0;padding:0 8px 8px;max-height:92px;overflow:auto;}
 .graphRiskBand span{display:inline-flex;align-items:center;min-height:18px;padding:1px 6px;border-radius:6px;border:1px solid rgba(239,68,68,.5);background:rgba(239,68,68,.12);color:var(--vscode-errorForeground,#ef4444);font-size:10px;font-weight:650;}
 .graphScroller{flex:1 1 auto;min-height:0;overflow:auto;overscroll-behavior:contain;background:var(--vscode-editor-background);}
-.graphCanvas{position:relative;min-width:100%;min-height:620px;background-color:var(--vscode-editor-background);background-image:linear-gradient(rgba(128,128,128,.1) 1px, transparent 1px),linear-gradient(90deg, rgba(128,128,128,.1) 1px, transparent 1px);background-size:48px 48px;}
+.graphCanvas{position:relative;min-width:100%;min-height:100%;background-color:var(--vscode-editor-background);background-image:linear-gradient(rgba(128,128,128,.1) 1px, transparent 1px),linear-gradient(90deg, rgba(128,128,128,.1) 1px, transparent 1px);background-size:48px 48px;}
 .graphContent{position:absolute;left:0;top:0;transform:scale(var(--graph-zoom,1));transform-origin:0 0;}
 .dependencyOverlay{position:absolute;inset:0;z-index:1;width:100%;height:100%;pointer-events:none;overflow:visible;}
 .dependencyPath{fill:none;stroke:rgba(148,163,184,.8);stroke-width:1.4;stroke-linecap:round;stroke-linejoin:round;vector-effect:non-scaling-stroke;}
@@ -920,10 +914,9 @@ th:nth-child(1){width:52px;}th:nth-child(2){width:72px;}th:nth-child(4){width:78
   .graphHeader{position:relative;padding:8px;margin:-8px -8px 0;}
   .graphIssueStack{padding:8px 0 0;}
   .graphMapFrame{margin:8px 0 0;}
-  .graphMapHeader{grid-template-columns:1fr;align-items:start;}
-  .graphControls{justify-content:flex-start;}
+  .graphMapHeader{align-items:start;}
   .graphLegend{justify-content:flex-start;}
-  .graphCanvas{min-height:560px;}
+  .graphCanvas{min-height:100%;}
 }
 code{font-family:var(--vscode-editor-font-family);}
 </style>

--- a/tests/beadsWebviewMetadata.test.ts
+++ b/tests/beadsWebviewMetadata.test.ts
@@ -51,8 +51,9 @@ describe("beads webview presentation metadata", () => {
     expect(beadsWebview).toContain("No dependency path yet");
     expect(beadsWebview).toContain("graphIssueDrawer");
     expect(beadsWebview).toContain("graphIssueStack");
-    expect(beadsWebview).toContain("graphControls");
-    expect(beadsWebview).toContain("data-graph-zoom-action");
+    expect(beadsWebview).not.toContain("graphControls");
+    expect(beadsWebview).not.toContain("data-graph-zoom-action");
+    expect(beadsWebview).not.toContain("graphZoomReset");
     expect(beadsWebview).toContain("graphScroller");
     expect(beadsWebview).toContain("graphContent");
     expect(beadsWebview).toContain("data-graph-width");
@@ -93,6 +94,11 @@ describe("beads webview presentation metadata", () => {
     expect(beadsWebview).toContain("initialDisplay");
     expect(beadsWebview).toContain("--graph-x");
     expect(beadsWebview).toContain("height:clamp(360px,calc(100vh - 132px),900px)");
+    expect(beadsWebview).toContain(
+      ".graphCanvas{position:relative;min-width:100%;min-height:100%;"
+    );
+    expect(beadsWebview).not.toContain("min-height:620px");
+    expect(beadsWebview).not.toContain("min-height:560px");
     expect(beadsWebview).toContain("#clearFilters{display:none;}");
     expect(beadsMain).toContain("getGraphRequiredSize");
     expect(beadsWebview).toContain("graphLevelGuide");
@@ -132,6 +138,10 @@ describe("beads webview presentation metadata", () => {
     expect(beadsMain).toContain("fitGraphToViewport");
     expect(beadsMain).toContain("availableWidth / requiredSize.width");
     expect(beadsMain).toContain("availableHeight / requiredSize.height");
+    expect(beadsMain).toContain("zoomGraphFromWheel");
+    expect(beadsMain).toContain('addEventListener("wheel"');
+    expect(beadsMain).toContain("passive: false");
+    expect(beadsMain).toContain("event.preventDefault()");
     expect(beadsMain).toContain("normalizeOptionalDatasetValue");
     expect(beadsMain).toContain("postAssignStartBead");
     expect(beadsMain).toContain('target.closest(".assignStartBead")');
@@ -157,9 +167,9 @@ describe("beads webview presentation metadata", () => {
     expect(beadsMain).toContain("visibleRowIds.has(node.dataset.graphId");
     expect(beadsMain).toContain('querySelectorAll<HTMLElement>(".graphPane")');
     expect(beadsMain).toContain('querySelector<HTMLElement>(".graphScroller")');
-    expect(beadsMain).toContain('getGraphScroller(pane)?.addEventListener("scroll"');
+    expect(beadsMain).toContain('scroller?.addEventListener("scroll"');
     expect(beadsMain).toContain("content.style.setProperty");
-    expect(beadsMain).toContain("data-graph-zoom-action");
+    expect(beadsMain).not.toContain("data-graph-zoom-action");
     expect(beadsMain).toContain('command: "assignStartBead"');
     expect(beadsMain).toContain('command: "startParallelBeads"');
     expect(beadsMain).toContain("detailsCell.colSpan = 6");

--- a/web/beadsMain.ts
+++ b/web/beadsMain.ts
@@ -13,6 +13,7 @@ type ViewMode = "table" | "graph";
 type BeadRow = HTMLTableRowElement & { dataset: DOMStringMap };
 type BeadSection = HTMLElement & { dataset: DOMStringMap };
 type GraphScrollState = { left: number; top: number };
+type GraphZoomAnchor = { pane: HTMLElement; clientX: number; clientY: number };
 type BeadsWebviewState = {
   viewMode?: ViewMode;
   graphZoom?: number;
@@ -65,7 +66,6 @@ const STATUS_LABELS: Record<StatusFilter, string> = {
 const ALL_FILTERS: StatusFilter[] = ["open", "in_progress", "blocked", "closed", "other"];
 const GRAPH_ZOOM_MIN = 0.05;
 const GRAPH_ZOOM_MAX = 1.8;
-const GRAPH_ZOOM_STEP = 0.1;
 const GRAPH_FIT_PADDING = 16;
 const PRESET_FILTERS: Record<string, StatusFilter[]> = {
   default: ["open", "in_progress", "blocked"],
@@ -824,15 +824,6 @@ function saveGraphScroll(pane: HTMLElement) {
   saveWebviewState({ graphScroll });
 }
 
-function updateGraphZoomLabels() {
-  const label = `${Math.round(graphZoom * 100)}%`;
-  for (const element of Array.from(
-    document.querySelectorAll<HTMLElement>("[data-graph-zoom-value]")
-  )) {
-    element.textContent = label;
-  }
-}
-
 function applyGraphZoomToPane(pane: HTMLElement) {
   const scroller = getGraphScroller(pane);
   const canvas = getGraphCanvas(pane);
@@ -853,7 +844,6 @@ function applyGraphZoomToAll() {
   for (const pane of Array.from(document.querySelectorAll<HTMLElement>(".graphPane"))) {
     applyGraphZoomToPane(pane);
   }
-  updateGraphZoomLabels();
 }
 
 function getGraphFitZoomForPane(pane: HTMLElement) {
@@ -900,40 +890,74 @@ function fitGraphToViewport() {
     saveGraphScroll(pane);
   }
   saveGraphZoom();
+  renderDependencyGraphOverlays();
 }
 
-function setGraphZoom(nextZoom: number) {
+function setGraphZoom(nextZoom: number, anchor?: GraphZoomAnchor) {
   const previousZoom = graphZoom;
   const nextNormalizedZoom = normalizeGraphZoom(nextZoom);
   if (Math.abs(previousZoom - nextNormalizedZoom) < 0.001) {
     return;
   }
 
-  const centers = new Map<HTMLElement, { x: number; y: number }>();
+  const anchors = new Map<
+    HTMLElement,
+    { x: number; y: number; offsetX: number; offsetY: number }
+  >();
   for (const pane of Array.from(document.querySelectorAll<HTMLElement>(".graphPane"))) {
     const scroller = getGraphScroller(pane);
     if (scroller === null) {
       continue;
     }
-    centers.set(pane, {
-      x: (scroller.scrollLeft + scroller.clientWidth / 2) / previousZoom,
-      y: (scroller.scrollTop + scroller.clientHeight / 2) / previousZoom
-    });
+    if (anchor !== undefined && anchor.pane === pane) {
+      const rect = scroller.getBoundingClientRect();
+      const offsetX = anchor.clientX - rect.left;
+      const offsetY = anchor.clientY - rect.top;
+      anchors.set(pane, {
+        x: (scroller.scrollLeft + offsetX) / previousZoom,
+        y: (scroller.scrollTop + offsetY) / previousZoom,
+        offsetX,
+        offsetY
+      });
+    } else {
+      const offsetX = scroller.clientWidth / 2;
+      const offsetY = scroller.clientHeight / 2;
+      anchors.set(pane, {
+        x: (scroller.scrollLeft + offsetX) / previousZoom,
+        y: (scroller.scrollTop + offsetY) / previousZoom,
+        offsetX,
+        offsetY
+      });
+    }
   }
 
   graphZoom = nextNormalizedZoom;
   applyGraphZoomToAll();
-  for (const [pane, center] of centers.entries()) {
+  for (const [pane, zoomAnchor] of anchors.entries()) {
     const scroller = getGraphScroller(pane);
     if (scroller === null) {
       continue;
     }
-    scroller.scrollLeft = Math.max(0, center.x * graphZoom - scroller.clientWidth / 2);
-    scroller.scrollTop = Math.max(0, center.y * graphZoom - scroller.clientHeight / 2);
+    scroller.scrollLeft = Math.max(0, zoomAnchor.x * graphZoom - zoomAnchor.offsetX);
+    scroller.scrollTop = Math.max(0, zoomAnchor.y * graphZoom - zoomAnchor.offsetY);
     saveGraphScroll(pane);
   }
   saveGraphZoom();
   renderDependencyGraphOverlays();
+}
+
+function zoomGraphFromWheel(pane: HTMLElement, event: WheelEvent) {
+  if (!event.ctrlKey && !event.metaKey) {
+    return;
+  }
+
+  event.preventDefault();
+  const zoomFactor = Math.exp(-event.deltaY * 0.002);
+  setGraphZoom(graphZoom * zoomFactor, {
+    pane,
+    clientX: event.clientX,
+    clientY: event.clientY
+  });
 }
 
 function renderDependencyGraphOverlays() {
@@ -1078,23 +1102,13 @@ window.addEventListener("resize", () => {
   renderDependencyGraphOverlays();
 });
 for (const pane of Array.from(document.querySelectorAll<HTMLElement>(".graphPane"))) {
-  getGraphScroller(pane)?.addEventListener("scroll", () => {
+  const scroller = getGraphScroller(pane);
+  scroller?.addEventListener("scroll", () => {
     saveGraphScroll(pane);
     renderDependencyGraphOverlays();
   });
-}
-for (const button of Array.from(
-  document.querySelectorAll<HTMLButtonElement>("[data-graph-zoom-action]")
-)) {
-  button.addEventListener("click", () => {
-    const action = button.dataset.graphZoomAction || "";
-    if (action === "in") {
-      setGraphZoom(graphZoom + GRAPH_ZOOM_STEP);
-    } else if (action === "out") {
-      setGraphZoom(graphZoom - GRAPH_ZOOM_STEP);
-    } else if (action === "reset") {
-      setGraphZoom(1);
-    }
+  scroller?.addEventListener("wheel", (event) => zoomGraphFromWheel(pane, event), {
+    passive: false
   });
 }
 queryElement<HTMLButtonElement>("#refresh").addEventListener("click", () => {


### PR DESCRIPTION
## Summary

- Make the Beads Graph view fit the visible task graph into the viewport by default.
- Replace the zoom button controls with wheel and trackpad zoom handling.

## Changes

- Remove the Graph zoom control buttons and related CSS/state label handling.
- Let the graph canvas shrink to the scroller height so auto-fit can avoid unnecessary scrollbars.
- Re-render dependency arrows after auto-fit and zoom changes.
- Add Ctrl/Meta wheel and trackpad pinch zoom support anchored at the pointer position.
- Update metadata tests for the buttonless zoom behavior and canvas sizing guard.

## Testing

- ./node_modules/.bin/oxfmt .
- git diff --check
- ./node_modules/.bin/oxlint
- ./node_modules/.bin/tsc -p ./src --noEmit
- ./node_modules/.bin/tsc -p ./web --noEmit
- ./node_modules/.bin/vitest run
- ./node_modules/.bin/esbuild --bundle src/extension.ts --outfile=out/extension.js --platform=node --format=cjs --target=es6 --external:vscode --minify
- ./node_modules/.bin/esbuild --bundle web/main.ts --outfile=out/web.min.js --minify --target=es6 --format=iife
- ./node_modules/.bin/esbuild --bundle web/beadsMain.ts --outfile=out/beadsWebview.min.js --minify --target=es6 --format=iife

## Notes

- bd sync is unavailable in this environment, so bd dolt push was used.