### PR TITLE
fix: stop Beads graph scrollbar flicker

### DIFF
--- a/src/beadsWebview.ts
+++ b/src/beadsWebview.ts
@@ -853,8 +853,8 @@ th:nth-child(1){width:52px;}th:nth-child(2){width:72px;}th:nth-child(4){width:78
 .graphWarningBand span{display:inline-flex;align-items:center;min-height:18px;padding:1px 6px;border-radius:6px;border:1px solid rgba(245,158,11,.5);background:rgba(245,158,11,.12);color:var(--vscode-editorWarning-foreground,#f59e0b);font-size:10px;font-weight:650;}
 .graphRiskBand{display:flex;flex-wrap:wrap;gap:4px;margin:0;padding:0 8px 8px;max-height:92px;overflow:auto;}
 .graphRiskBand span{display:inline-flex;align-items:center;min-height:18px;padding:1px 6px;border-radius:6px;border:1px solid rgba(239,68,68,.5);background:rgba(239,68,68,.12);color:var(--vscode-errorForeground,#ef4444);font-size:10px;font-weight:650;}
-.graphScroller{flex:1 1 auto;min-height:0;overflow:auto;overscroll-behavior:contain;background:var(--vscode-editor-background);}
-.graphCanvas{position:relative;min-width:100%;min-height:100%;background-color:var(--vscode-editor-background);background-image:linear-gradient(rgba(128,128,128,.1) 1px, transparent 1px),linear-gradient(90deg, rgba(128,128,128,.1) 1px, transparent 1px);background-size:48px 48px;}
+.graphScroller{flex:1 1 auto;min-height:0;overflow:auto;overscroll-behavior:contain;scrollbar-gutter:stable;background:var(--vscode-editor-background);}
+.graphCanvas{position:relative;min-width:100%;min-height:100%;overflow:hidden;background-color:var(--vscode-editor-background);background-image:linear-gradient(rgba(128,128,128,.1) 1px, transparent 1px),linear-gradient(90deg, rgba(128,128,128,.1) 1px, transparent 1px);background-size:48px 48px;}
 .graphContent{position:absolute;left:0;top:0;transform:scale(var(--graph-zoom,1));transform-origin:0 0;}
 .dependencyOverlay{position:absolute;inset:0;z-index:1;width:100%;height:100%;pointer-events:none;overflow:visible;}
 .dependencyPath{fill:none;stroke:rgba(148,163,184,.8);stroke-width:1.4;stroke-linecap:round;stroke-linejoin:round;vector-effect:non-scaling-stroke;}

--- a/tests/beadsWebviewMetadata.test.ts
+++ b/tests/beadsWebviewMetadata.test.ts
@@ -94,8 +94,9 @@ describe("beads webview presentation metadata", () => {
     expect(beadsWebview).toContain("initialDisplay");
     expect(beadsWebview).toContain("--graph-x");
     expect(beadsWebview).toContain("height:clamp(360px,calc(100vh - 132px),900px)");
+    expect(beadsWebview).toContain("scrollbar-gutter:stable");
     expect(beadsWebview).toContain(
-      ".graphCanvas{position:relative;min-width:100%;min-height:100%;"
+      ".graphCanvas{position:relative;min-width:100%;min-height:100%;overflow:hidden;"
     );
     expect(beadsWebview).not.toContain("min-height:620px");
     expect(beadsWebview).not.toContain("min-height:560px");
@@ -168,6 +169,7 @@ describe("beads webview presentation metadata", () => {
     expect(beadsMain).toContain('querySelectorAll<HTMLElement>(".graphPane")');
     expect(beadsMain).toContain('querySelector<HTMLElement>(".graphScroller")');
     expect(beadsMain).toContain('scroller?.addEventListener("scroll"');
+    expect(beadsMain).not.toContain("saveGraphScroll(pane);\n    renderDependencyGraphOverlays();");
     expect(beadsMain).toContain("content.style.setProperty");
     expect(beadsMain).not.toContain("data-graph-zoom-action");
     expect(beadsMain).toContain('command: "assignStartBead"');

--- a/web/beadsMain.ts
+++ b/web/beadsMain.ts
@@ -509,9 +509,8 @@ function refreshRowVisibility() {
   renderHierarchyOverlays();
   if (activeViewMode === "graph") {
     fitGraphToViewport();
-  } else {
-    renderDependencyGraphOverlays();
   }
+  renderDependencyGraphOverlays();
 }
 
 function applyFilters() {
@@ -890,7 +889,6 @@ function fitGraphToViewport() {
     saveGraphScroll(pane);
   }
   saveGraphZoom();
-  renderDependencyGraphOverlays();
 }
 
 function setGraphZoom(nextZoom: number, anchor?: GraphZoomAnchor) {
@@ -974,8 +972,6 @@ function renderDependencyGraphOverlays() {
       overlay.innerHTML = "";
       continue;
     }
-
-    applyGraphZoomToPane(pane);
 
     const contentRect = content.getBoundingClientRect();
     const width = Math.max(1, Math.round(content.offsetWidth));
@@ -1105,7 +1101,6 @@ for (const pane of Array.from(document.querySelectorAll<HTMLElement>(".graphPane
   const scroller = getGraphScroller(pane);
   scroller?.addEventListener("scroll", () => {
     saveGraphScroll(pane);
-    renderDependencyGraphOverlays();
   });
   scroller?.addEventListener("wheel", (event) => zoomGraphFromWheel(pane, event), {
     passive: false


### PR DESCRIPTION
## Summary

- Stop the Beads Graph canvas scrollbar from flickering during graph rendering and scrolling.

## Changes

- Remove dependency overlay re-rendering from Graph scroll events.
- Keep overlay rendering from resizing the graph canvas.
- Avoid duplicate overlay rendering inside graph auto-fit.
- Stabilize the graph scroller gutter and hide fractional canvas overflow.
- Add metadata test coverage for the scrollbar flicker guard.

## Testing

- ./node_modules/.bin/oxfmt .
- git diff --check
- ./node_modules/.bin/oxlint
- ./node_modules/.bin/tsc -p ./src --noEmit
- ./node_modules/.bin/tsc -p ./web --noEmit
- ./node_modules/.bin/vitest run
- ./node_modules/.bin/esbuild --bundle src/extension.ts --outfile=out/extension.js --platform=node --format=cjs --target=es6 --external:vscode --minify
- ./node_modules/.bin/esbuild --bundle web/main.ts --outfile=out/web.min.js --minify --target=es6 --format=iife
- ./node_modules/.bin/esbuild --bundle web/beadsMain.ts --outfile=out/beadsWebview.min.js --minify --target=es6 --format=iife

## Notes

- bd sync is unavailable in this environment, so bd dolt push was used.