### PR TITLE
chore: release v0.4.20260708

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+## [0.4.20260708] - 2026-07-08
+
+### Fixed
+
+- Keep Beads table rows in a stable order instead of reordering them by updated timestamps during refresh.
+- Fit the Beads Graph view to the visible task graph by default.
+- Replace Graph zoom buttons with wheel and trackpad zoom handling.
+- Stop the Graph canvas scrollbar from flickering during rendering and scrolling.
+
 ## [0.4.20260706] - 2026-07-06
 
 ### Fixed
@@ -360,7 +369,8 @@
 
 Initial release
 
-[Unreleased]: https://github.com/ToppyMicroServices/beads-git-graph/compare/v0.4.20260706...HEAD
+[Unreleased]: https://github.com/ToppyMicroServices/beads-git-graph/compare/v0.4.20260708...HEAD
+[0.4.20260708]: https://github.com/ToppyMicroServices/beads-git-graph/compare/v0.4.20260706...v0.4.20260708
 [0.4.20260706]: https://github.com/ToppyMicroServices/beads-git-graph/compare/v0.4.20260703...v0.4.20260706
 [0.4.20260703]: https://github.com/ToppyMicroServices/beads-git-graph/compare/v0.4.20260702...v0.4.20260703
 [0.4.20260702]: https://github.com/ToppyMicroServices/beads-git-graph/compare/v0.3.4...v0.4.20260702

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Beads Git Graph
 
 [![MIT License](https://img.shields.io/badge/license-MIT-2ea44f?style=flat-square)](./LICENSE)
-[![Version 0.4.20260706](https://img.shields.io/badge/version-0.4.20260706-0366d6?style=flat-square)](./CHANGELOG.md)
+[![Version 0.4.20260708](https://img.shields.io/badge/version-0.4.20260708-0366d6?style=flat-square)](./CHANGELOG.md)
 
 Git graph and Beads issue tools in one VS Code extension.
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "beads-git-graph",
   "displayName": "Beads Git Graph",
-  "version": "0.4.20260706",
+  "version": "0.4.20260708",
   "description": "Git graph and Beads issue tools for VS Code.",
   "categories": [
     "Other",


### PR DESCRIPTION
## Summary

- Prepare the stable v0.4.20260708 release for Marketplace publishing.

## Changes

- Bump package version to 0.4.20260708.
- Add v0.4.20260708 changelog entries for the Beads table and Graph view fixes.
- Update the README version badge.

## Testing

- ./node_modules/.bin/oxfmt .
- git diff --check
- ./node_modules/.bin/oxlint
- ./node_modules/.bin/tsc -p ./src --noEmit
- ./node_modules/.bin/tsc -p ./web --noEmit
- ./node_modules/.bin/vitest run
- env CI=true pnpm run package
- Verified beads-git-graph-0.4.20260708.vsix contains extension/package.json version 0.4.20260708.

## Notes

- bd sync is unavailable in this environment, so bd dolt push was used.
- The first package attempt needed CI=true because pnpm cannot prompt in this environment; npm registry access also required an approved network run.