### PR TITLE
fix: stabilize Beads table and graph views

### DIFF
--- a/src/beadsHierarchy.ts
+++ b/src/beadsHierarchy.ts
@@ -71,6 +71,7 @@ export function flattenBeadHierarchy(items: BeadItem[]): BeadRenderItem[] {
     visited.add(entry.item.id);
     ordered.push({
       ...entry,
+      orderIndex: ordered.length,
       guideColumns,
       isLastSibling
     });

--- a/src/beadsWebview.ts
+++ b/src/beadsWebview.ts
@@ -853,7 +853,7 @@ th:nth-child(1){width:52px;}th:nth-child(2){width:72px;}th:nth-child(4){width:78
 .graphWarningBand span{display:inline-flex;align-items:center;min-height:18px;padding:1px 6px;border-radius:6px;border:1px solid rgba(245,158,11,.5);background:rgba(245,158,11,.12);color:var(--vscode-editorWarning-foreground,#f59e0b);font-size:10px;font-weight:650;}
 .graphRiskBand{display:flex;flex-wrap:wrap;gap:4px;margin:0;padding:0 8px 8px;max-height:92px;overflow:auto;}
 .graphRiskBand span{display:inline-flex;align-items:center;min-height:18px;padding:1px 6px;border-radius:6px;border:1px solid rgba(239,68,68,.5);background:rgba(239,68,68,.12);color:var(--vscode-errorForeground,#ef4444);font-size:10px;font-weight:650;}
-.graphScroller{flex:1 1 auto;min-height:0;overflow:auto;overscroll-behavior:contain;scrollbar-gutter:stable;background:var(--vscode-editor-background);}
+.graphScroller{flex:1 1 auto;min-height:0;overflow:hidden;overscroll-behavior:contain;background:var(--vscode-editor-background);}
 .graphCanvas{position:relative;min-width:100%;min-height:100%;overflow:hidden;background-color:var(--vscode-editor-background);background-image:linear-gradient(rgba(128,128,128,.1) 1px, transparent 1px),linear-gradient(90deg, rgba(128,128,128,.1) 1px, transparent 1px);background-size:48px 48px;}
 .graphContent{position:absolute;left:0;top:0;transform:scale(var(--graph-zoom,1));transform-origin:0 0;}
 .dependencyOverlay{position:absolute;inset:0;z-index:1;width:100%;height:100%;pointer-events:none;overflow:visible;}

--- a/tests/beadsHierarchy.test.ts
+++ b/tests/beadsHierarchy.test.ts
@@ -31,6 +31,7 @@ describe("flattenBeadHierarchy", () => {
       "demo-root-a.1",
       "demo-root-b"
     ]);
+    expect(flattenBeadHierarchy(items).map((entry) => entry.orderIndex)).toEqual([0, 1, 2]);
   });
 
   it("produces guide column metadata for nested demo tasks", () => {

--- a/tests/beadsWebviewMetadata.test.ts
+++ b/tests/beadsWebviewMetadata.test.ts
@@ -94,7 +94,8 @@ describe("beads webview presentation metadata", () => {
     expect(beadsWebview).toContain("initialDisplay");
     expect(beadsWebview).toContain("--graph-x");
     expect(beadsWebview).toContain("height:clamp(360px,calc(100vh - 132px),900px)");
-    expect(beadsWebview).toContain("scrollbar-gutter:stable");
+    expect(beadsWebview).toContain(".graphScroller{flex:1 1 auto;min-height:0;overflow:hidden;");
+    expect(beadsWebview).not.toContain("scrollbar-gutter:stable");
     expect(beadsWebview).toContain(
       ".graphCanvas{position:relative;min-width:100%;min-height:100%;overflow:hidden;"
     );
@@ -102,6 +103,7 @@ describe("beads webview presentation metadata", () => {
     expect(beadsWebview).not.toContain("min-height:560px");
     expect(beadsWebview).toContain("#clearFilters{display:none;}");
     expect(beadsMain).toContain("getGraphRequiredSize");
+    expect(beadsMain).toContain("getGraphViewportSize");
     expect(beadsWebview).toContain("graphLevelGuide");
     expect(beadsWebview).toContain("graphLevelLabel");
     expect(beadsWebview).toContain("No blockers");
@@ -139,6 +141,11 @@ describe("beads webview presentation metadata", () => {
     expect(beadsMain).toContain("fitGraphToViewport");
     expect(beadsMain).toContain("availableWidth / requiredSize.width");
     expect(beadsMain).toContain("availableHeight / requiredSize.height");
+    const interpolationStart = String.fromCharCode(36) + "{";
+    expect(beadsMain).toContain(`canvas.style.width = \`${interpolationStart}viewport.width}px\``);
+    expect(beadsMain).toContain(
+      `canvas.style.height = \`${interpolationStart}viewport.height}px\``
+    );
     expect(beadsMain).toContain("zoomGraphFromWheel");
     expect(beadsMain).toContain('addEventListener("wheel"');
     expect(beadsMain).toContain("passive: false");

--- a/web/beadsMain.ts
+++ b/web/beadsMain.ts
@@ -792,6 +792,14 @@ function getGraphBaseSize(canvas: HTMLElement) {
   };
 }
 
+function getGraphViewportSize(scroller: HTMLElement) {
+  const rect = scroller.getBoundingClientRect();
+  return {
+    width: Math.max(1, Math.floor(rect.width || scroller.clientWidth || 1)),
+    height: Math.max(1, Math.floor(rect.height || scroller.clientHeight || 1))
+  };
+}
+
 function getGraphRequiredSize(pane: HTMLElement, base: { width: number; height: number }) {
   let width = base.width;
   let height = base.height;
@@ -832,10 +840,11 @@ function applyGraphZoomToPane(pane: HTMLElement) {
   }
 
   const base = getGraphRequiredSize(pane, getGraphBaseSize(canvas));
+  const viewport = getGraphViewportSize(scroller);
   content.style.width = `${base.width}px`;
   content.style.height = `${base.height}px`;
-  canvas.style.width = `${Math.max(scroller.clientWidth, base.width * graphZoom)}px`;
-  canvas.style.height = `${Math.max(scroller.clientHeight, base.height * graphZoom)}px`;
+  canvas.style.width = `${viewport.width}px`;
+  canvas.style.height = `${viewport.height}px`;
   content.style.setProperty("--graph-zoom", graphZoom.toFixed(2));
 }
 
@@ -848,18 +857,18 @@ function applyGraphZoomToAll() {
 function getGraphFitZoomForPane(pane: HTMLElement) {
   const scroller = getGraphScroller(pane);
   const canvas = getGraphCanvas(pane);
-  if (
-    scroller === null ||
-    canvas === null ||
-    scroller.clientWidth <= 0 ||
-    scroller.clientHeight <= 0
-  ) {
+  if (scroller === null || canvas === null) {
+    return 1;
+  }
+
+  const viewport = getGraphViewportSize(scroller);
+  if (viewport.width <= 1 || viewport.height <= 1) {
     return 1;
   }
 
   const requiredSize = getGraphRequiredSize(pane, { width: 1, height: 1 });
-  const availableWidth = Math.max(1, scroller.clientWidth - GRAPH_FIT_PADDING * 2);
-  const availableHeight = Math.max(1, scroller.clientHeight - GRAPH_FIT_PADDING * 2);
+  const availableWidth = Math.max(1, viewport.width - GRAPH_FIT_PADDING * 2);
+  const availableHeight = Math.max(1, viewport.height - GRAPH_FIT_PADDING * 2);
   const fitZoom = Math.min(
     1,
     availableWidth / requiredSize.width,


### PR DESCRIPTION
## Summary

- Stabilize Beads table ordering and Graph viewport fitting.

## Changes

- Use the final flattened hierarchy order for table default order indices.
- Size Graph canvas from the viewport instead of scrollbar-sensitive client dimensions.
- Hide Graph scrollbars so auto-fit does not enter a scrollbar/resize feedback loop.
- Add regression coverage for stable order and Graph viewport sizing metadata.

## Testing

- ./node_modules/.bin/oxfmt .
- git diff --check
- ./node_modules/.bin/oxlint
- ./node_modules/.bin/tsc -p ./src --noEmit
- ./node_modules/.bin/tsc -p ./web --noEmit
- ./node_modules/.bin/vitest run
- node_modules/.pnpm/esbuild@0.28.1/node_modules/esbuild/bin/esbuild --bundle src/extension.ts --outfile=/tmp/beads-extension.js --platform=node --format=cjs --target=es6 --external:vscode --minify
- node_modules/.pnpm/esbuild@0.28.1/node_modules/esbuild/bin/esbuild --bundle web/main.ts --outfile=/tmp/beads-web-main.js --minify --target=es6 --format=iife
- node_modules/.pnpm/esbuild@0.28.1/node_modules/esbuild/bin/esbuild --bundle web/beadsMain.ts --outfile=/tmp/beads-webview.js --minify --target=es6 --format=iife

## Notes

- bd sync is unavailable in this local bd CLI; used bd dolt push instead.