### PR TITLE
chore: release v0.4.20260709

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+## [0.4.20260709] - 2026-07-08
+
+### Fixed
+
+- Stabilize the Beads table default order across task updates.
+- Fit the Beads Graph view without scrollbar-driven resize flicker.
+
 ## [0.4.20260708] - 2026-07-08
 
 ### Fixed
@@ -369,7 +376,8 @@
 
 Initial release
 
-[Unreleased]: https://github.com/ToppyMicroServices/beads-git-graph/compare/v0.4.20260708...HEAD
+[Unreleased]: https://github.com/ToppyMicroServices/beads-git-graph/compare/v0.4.20260709...HEAD
+[0.4.20260709]: https://github.com/ToppyMicroServices/beads-git-graph/compare/v0.4.20260708...v0.4.20260709
 [0.4.20260708]: https://github.com/ToppyMicroServices/beads-git-graph/compare/v0.4.20260706...v0.4.20260708
 [0.4.20260706]: https://github.com/ToppyMicroServices/beads-git-graph/compare/v0.4.20260703...v0.4.20260706
 [0.4.20260703]: https://github.com/ToppyMicroServices/beads-git-graph/compare/v0.4.20260702...v0.4.20260703

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Beads Git Graph
 
 [![MIT License](https://img.shields.io/badge/license-MIT-2ea44f?style=flat-square)](./LICENSE)
-[![Version 0.4.20260708](https://img.shields.io/badge/version-0.4.20260708-0366d6?style=flat-square)](./CHANGELOG.md)
+[![Version 0.4.20260709](https://img.shields.io/badge/version-0.4.20260709-0366d6?style=flat-square)](./CHANGELOG.md)
 
 Git graph and Beads issue tools in one VS Code extension.
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "beads-git-graph",
   "displayName": "Beads Git Graph",
-  "version": "0.4.20260708",
+  "version": "0.4.20260709",
   "description": "Git graph and Beads issue tools for VS Code.",
   "categories": [
     "Other",


### PR DESCRIPTION
## Summary

- Prepare v0.4.20260709 for Marketplace publication.

## Changes

- Bump extension version to 0.4.20260709.
- Update README version badge.
- Add changelog notes for the Beads table and Graph display stabilization release.

## Testing

- ./node_modules/.bin/oxfmt .
- git diff --check
- ./node_modules/.bin/oxlint
- ./node_modules/.bin/tsc -p ./src --noEmit
- ./node_modules/.bin/tsc -p ./web --noEmit
- ./node_modules/.bin/vitest run
- node_modules/.pnpm/esbuild@0.28.1/node_modules/esbuild/bin/esbuild --bundle web/beadsMain.ts --outfile=/tmp/beads-webview-release.js --minify --target=es6 --format=iife

## Notes

- Local pnpm run package was blocked by pnpm v11 build approval state after dependency restoration; packaging and Marketplace publish will run in the GitHub release workflow.
- bd sync is unavailable in this local bd CLI; used bd dolt push instead.