### PR TITLE
fix: improve Beads graph readability

### DIFF
--- a/src/beadsWebview.ts
+++ b/src/beadsWebview.ts
@@ -19,6 +19,7 @@ const BEADS_WEBVIEW_SCRIPT = "beadsWebview.min.js";
 const GRAPH_NODE_WIDTH = 252;
 const GRAPH_NODE_HEIGHT_ESTIMATE = 140;
 const GRAPH_LEVEL_GAP = 56;
+const GRAPH_LEVEL_COLUMN_GAP = 24;
 const GRAPH_LANE_GAP = 30;
 const GRAPH_PADDING_X = 28;
 const GRAPH_PADDING_Y = 44;
@@ -243,34 +244,47 @@ function renderBeadsDependencyGraph(
         `<span class="graphEdge" data-from-id="${escapeHtml(edge.fromId)}" data-to-id="${escapeHtml(edge.toId)}" data-critical="${edge.critical ? "1" : "0"}"></span>`
     )
     .join("");
-  const laneCount = Math.max(1, ...Array.from(nodesByLevel.values()).map((nodes) => nodes.length));
   const levelCount = maxLevel + 1;
-  const graphWidth =
-    GRAPH_PADDING_X * 2 +
-    levelCount * GRAPH_NODE_WIDTH +
-    Math.max(0, levelCount - 1) * GRAPH_LEVEL_GAP;
+  const levelLayouts = Array.from({ length: levelCount }, (_, level) => {
+    const nodes = nodesByLevel.get(level) ?? [];
+    const rowCount = Math.max(1, Math.ceil(Math.sqrt(Math.max(1, nodes.length))));
+    const columnCount = Math.max(1, Math.ceil(Math.max(1, nodes.length) / rowCount));
+    const width =
+      columnCount * GRAPH_NODE_WIDTH + Math.max(0, columnCount - 1) * GRAPH_LEVEL_COLUMN_GAP;
+
+    return { nodes, rowCount, columnCount, width, x: 0 };
+  });
+  let nextLevelX = GRAPH_PADDING_X;
+  for (const layout of levelLayouts) {
+    layout.x = nextLevelX;
+    nextLevelX += layout.width + GRAPH_LEVEL_GAP;
+  }
+  const graphRowCount = Math.max(1, ...levelLayouts.map((layout) => layout.rowCount));
+  const graphWidth = nextLevelX - GRAPH_LEVEL_GAP + GRAPH_PADDING_X;
   const graphHeight =
     GRAPH_PADDING_Y * 2 +
-    laneCount * GRAPH_NODE_HEIGHT_ESTIMATE +
-    Math.max(0, laneCount - 1) * GRAPH_LANE_GAP;
+    graphRowCount * GRAPH_NODE_HEIGHT_ESTIMATE +
+    Math.max(0, graphRowCount - 1) * GRAPH_LANE_GAP;
   const levelGuideHtml = Array.from({ length: levelCount }, (_, level) => {
-    const x = GRAPH_PADDING_X + level * (GRAPH_NODE_WIDTH + GRAPH_LEVEL_GAP) + GRAPH_NODE_WIDTH / 2;
+    const layout = levelLayouts[level];
+    const x = layout.x + layout.width / 2;
     const label = level === 0 ? "Ready" : `L${level + 1}`;
     const detail = level === 0 ? "No blockers" : "After deps";
 
     return `<span class="graphLevelGuide" style="--graph-guide-x:${x}px"><span class="graphLevelLabel"><strong>${label}</strong><small>${detail}</small></span></span>`;
   }).join("");
   const nodeHtml = Array.from({ length: levelCount }, (_, level) => {
-    const nodes = nodesByLevel.get(level) ?? [];
-    const laneOffset =
-      ((laneCount - nodes.length) * (GRAPH_NODE_HEIGHT_ESTIMATE + GRAPH_LANE_GAP)) / 2;
+    const layout = levelLayouts[level];
+    const rowOffset =
+      ((graphRowCount - layout.rowCount) * (GRAPH_NODE_HEIGHT_ESTIMATE + GRAPH_LANE_GAP)) / 2;
 
-    return nodes
+    return layout.nodes
       .map((node, lane) => {
         const item = node.item;
-        const x = GRAPH_PADDING_X + level * (GRAPH_NODE_WIDTH + GRAPH_LEVEL_GAP);
-        const y =
-          GRAPH_PADDING_Y + laneOffset + lane * (GRAPH_NODE_HEIGHT_ESTIMATE + GRAPH_LANE_GAP);
+        const column = Math.floor(lane / layout.rowCount);
+        const row = lane % layout.rowCount;
+        const x = layout.x + column * (GRAPH_NODE_WIDTH + GRAPH_LEVEL_COLUMN_GAP);
+        const y = GRAPH_PADDING_Y + rowOffset + row * (GRAPH_NODE_HEIGHT_ESTIMATE + GRAPH_LANE_GAP);
         const normalizedStatus = normalizeBeadStatus(item.status);
         const normalizedPriority = normalizeBeadPriority(item.priority);
         const normalizedType = normalizeBeadType(item.type);

--- a/tests/beadsWebviewMetadata.test.ts
+++ b/tests/beadsWebviewMetadata.test.ts
@@ -116,7 +116,10 @@ describe("beads webview presentation metadata", () => {
     expect(beadsWebview).toContain("dependencyArrowHead");
     expect(beadsWebview).toContain("const GRAPH_NODE_WIDTH = 252");
     expect(beadsWebview).toContain("const GRAPH_LEVEL_GAP = 56");
+    expect(beadsWebview).toContain("const GRAPH_LEVEL_COLUMN_GAP = 24");
     expect(beadsWebview).toContain("const GRAPH_LANE_GAP = 30");
+    expect(beadsWebview).toContain("const levelLayouts = Array.from");
+    expect(beadsWebview).toContain("Math.ceil(Math.sqrt");
     expect(beadsWebview).toContain("stroke-width:2;");
     expect(beadsWebview).toContain("Sort by updated");
     expect(beadsWebview).not.toContain('data-sort-key="updated">▼');
@@ -147,6 +150,8 @@ describe("beads webview presentation metadata", () => {
       `canvas.style.height = \`${interpolationStart}viewport.height}px\``
     );
     expect(beadsMain).toContain("zoomGraphFromWheel");
+    expect(beadsMain).not.toContain("event.ctrlKey");
+    expect(beadsMain).not.toContain("event.metaKey");
     expect(beadsMain).toContain('addEventListener("wheel"');
     expect(beadsMain).toContain("passive: false");
     expect(beadsMain).toContain("event.preventDefault()");

--- a/web/beadsMain.ts
+++ b/web/beadsMain.ts
@@ -954,10 +954,6 @@ function setGraphZoom(nextZoom: number, anchor?: GraphZoomAnchor) {
 }
 
 function zoomGraphFromWheel(pane: HTMLElement, event: WheelEvent) {
-  if (!event.ctrlKey && !event.metaKey) {
-    return;
-  }
-
   event.preventDefault();
   const zoomFactor = Math.exp(-event.deltaY * 0.002);
   setGraphZoom(graphZoom * zoomFactor, {


### PR DESCRIPTION
## Summary

- Make the Beads Graph view readable when many tasks share the same dependency level.

## Changes

- Pack nodes within each dependency level into compact columns instead of a single tall lane.
- Keep dependency levels left-to-right while reducing excessive vertical height.
- Update presentation metadata tests for the wrapped level layout.

## Testing

- ./node_modules/.bin/oxfmt .
- git diff --check
- ./node_modules/.bin/oxlint
- ./node_modules/.bin/tsc -p ./src --noEmit
- ./node_modules/.bin/tsc -p ./web --noEmit
- ./node_modules/.bin/vitest run
- node_modules/.pnpm/esbuild@0.28.1/node_modules/esbuild/bin/esbuild --bundle web/beadsMain.ts --outfile=/tmp/beads-webview-readable-graph.js --minify --target=es6 --format=iife

## Notes

- bd sync is unavailable in this local bd CLI; used bd dolt push instead.