### PR TITLE
chore: release v0.4.20260710

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+## [0.4.20260710] - 2026-07-08
+
+### Fixed
+
+- Make the Beads Graph view readable when many tasks share one dependency level.
+- Allow wheel and trackpad zoom directly on the Beads Graph view.
+
 ## [0.4.20260709] - 2026-07-08
 
 ### Fixed
@@ -376,7 +383,8 @@
 
 Initial release
 
-[Unreleased]: https://github.com/ToppyMicroServices/beads-git-graph/compare/v0.4.20260709...HEAD
+[Unreleased]: https://github.com/ToppyMicroServices/beads-git-graph/compare/v0.4.20260710...HEAD
+[0.4.20260710]: https://github.com/ToppyMicroServices/beads-git-graph/compare/v0.4.20260709...v0.4.20260710
 [0.4.20260709]: https://github.com/ToppyMicroServices/beads-git-graph/compare/v0.4.20260708...v0.4.20260709
 [0.4.20260708]: https://github.com/ToppyMicroServices/beads-git-graph/compare/v0.4.20260706...v0.4.20260708
 [0.4.20260706]: https://github.com/ToppyMicroServices/beads-git-graph/compare/v0.4.20260703...v0.4.20260706

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Beads Git Graph
 
 [![MIT License](https://img.shields.io/badge/license-MIT-2ea44f?style=flat-square)](./LICENSE)
-[![Version 0.4.20260709](https://img.shields.io/badge/version-0.4.20260709-0366d6?style=flat-square)](./CHANGELOG.md)
+[![Version 0.4.20260710](https://img.shields.io/badge/version-0.4.20260710-0366d6?style=flat-square)](./CHANGELOG.md)
 
 Git graph and Beads issue tools in one VS Code extension.
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "beads-git-graph",
   "displayName": "Beads Git Graph",
-  "version": "0.4.20260709",
+  "version": "0.4.20260710",
   "description": "Git graph and Beads issue tools for VS Code.",
   "categories": [
     "Other",


### PR DESCRIPTION
## Summary

- Prepare v0.4.20260710 for Marketplace publication.

## Changes

- Bump extension version to 0.4.20260710.
- Update README version badge.
- Add changelog notes for Graph readability and wheel/trackpad zoom handling.

## Testing

- ./node_modules/.bin/oxfmt .
- git diff --check
- ./node_modules/.bin/oxlint
- ./node_modules/.bin/tsc -p ./src --noEmit
- ./node_modules/.bin/tsc -p ./web --noEmit
- ./node_modules/.bin/vitest run

## Notes

- bd sync is unavailable in this local bd CLI; used bd dolt push instead.