### PR TITLE
feat: add rectangle zoom to Beads graph

### DIFF
--- a/src/beadsWebview.ts
+++ b/src/beadsWebview.ts
@@ -52,6 +52,10 @@ function encodeJsonData(value: unknown) {
   return escapeHtml(encodeURIComponent(JSON.stringify(value)));
 }
 
+function getBeadDetailsId(workspacePath: string, issueId: string) {
+  return `bead-details-${encodeURIComponent(`${workspacePath}:${issueId}`).replace(/%/g, "_")}`;
+}
+
 function isDefaultVisibleStatus(status: string) {
   return status === "open" || status === "in_progress" || status === "blocked";
 }
@@ -271,7 +275,7 @@ function renderBeadsDependencyGraph(
     const label = level === 0 ? "Ready" : `L${level + 1}`;
     const detail = level === 0 ? "No blockers" : "After deps";
 
-    return `<span class="graphLevelGuide" style="--graph-guide-x:${x}px"><span class="graphLevelLabel"><strong>${label}</strong><small>${detail}</small></span></span>`;
+    return `<span class="graphLevelGuide" data-graph-level="${level}" style="--graph-guide-x:${x}px"><span class="graphLevelLabel"><strong>${label}</strong><small>${detail}</small></span></span>`;
   }).join("");
   const nodeHtml = Array.from({ length: levelCount }, (_, level) => {
     const layout = levelLayouts[level];
@@ -310,13 +314,13 @@ function renderBeadsDependencyGraph(
         const depth = hierarchyEntry?.depth ?? 0;
         const dependencyLines = [
           parentId !== "" && itemsById.has(parentId)
-            ? `<div class="graphRelation graphParentRelation"><span>Parent</span>${escapeHtml(parentId)}</div>`
+            ? `<div class="graphRelation graphParentRelation" data-related-ids="${encodeJsonData([parentId])}"><span>Parent</span><strong class="graphRelationValue">${escapeHtml(parentId)}</strong></div>`
             : "",
           blockers.length > 0
-            ? `<div class="graphRelation"><span>Depends</span>${escapeHtml(blockers.join(", "))}</div>`
+            ? `<div class="graphRelation" data-related-ids="${encodeJsonData(blockers)}"><span>Depends</span><strong class="graphRelationValue">${escapeHtml(blockers.join(", "))}</strong></div>`
             : "",
           blocks.length > 0
-            ? `<div class="graphRelation"><span>Blocks</span>${escapeHtml(blocks.join(", "))}</div>`
+            ? `<div class="graphRelation" data-related-ids="${encodeJsonData(blocks)}"><span>Blocks</span><strong class="graphRelationValue">${escapeHtml(blocks.join(", "))}</strong></div>`
             : ""
         ]
           .filter((line) => line !== "")
@@ -366,7 +370,7 @@ function renderBeadsDependencyGraph(
         ]
           .filter((badge) => badge !== "")
           .join("");
-        return `<div class="graphNode ${node.critical ? "criticalGraphNode" : ""}${dependencyWarning === "" ? "" : " dependencyWarningGraphNode"}${mergeRiskWarning === "" ? "" : " mergeRiskGraphNode"}" data-graph-id="${escapeHtml(item.id)}" data-graph-level="${level}" data-graph-lane="${lane}" data-status="${escapeHtml(normalizedStatus)}" data-critical="${node.critical ? "1" : "0"}" data-parent-id="${escapeHtml(parentId)}" data-epic-id="${escapeHtml(epicId ?? "")}" data-depth="${depth}" style="${initialDisplay}--graph-x:${x}px;--graph-y:${y}px"><div class="graphNodeTop"><span class="typeBadge type-${escapeHtml(normalizedType)}">${escapeHtml(item.type)}</span>${node.critical ? '<span class="criticalBadge">Critical path</span>' : ""}</div><div class="beadId">${escapeHtml(item.id)}</div><div class="graphNodeTitle">${escapeHtml(item.title)}</div><div class="graphNodeBadges"><span class="statusBadge status-${escapeHtml(normalizedStatus.replace(/_/g, "-"))}">${escapeHtml(beadStatusLabel(normalizedStatus))}</span><span class="priorityBadge priority-${escapeHtml(normalizedPriority.toLowerCase())}">${escapeHtml(normalizedPriority)}</span>${graphBadges}</div>${dependencyWarning === "" ? "" : `<div class="graphWarning">${escapeHtml(dependencyWarning)}</div>`}${mergeRiskWarning === "" ? "" : `<div class="graphWarning graphMergeRisk">${escapeHtml(mergeRiskWarning)}</div>`}${dependencyLines === "" ? "" : `<div class="graphRelations">${dependencyLines}</div>`}<div class="graphNodeActions">${actionHtml}</div></div>`;
+        return `<div class="graphNode ${node.critical ? "criticalGraphNode" : ""}${dependencyWarning === "" ? "" : " dependencyWarningGraphNode"}${mergeRiskWarning === "" ? "" : " mergeRiskGraphNode"}" data-graph-id="${escapeHtml(item.id)}" data-graph-level="${level}" data-graph-lane="${lane}" data-status="${escapeHtml(normalizedStatus)}" data-critical="${node.critical ? "1" : "0"}" data-parent-id="${escapeHtml(parentId)}" data-epic-id="${escapeHtml(epicId ?? "")}" data-depth="${depth}" style="${initialDisplay}--graph-x:${x}px;--graph-y:${y}px"><div class="graphNodeTop"><span class="typeBadge type-${escapeHtml(normalizedType)}">${escapeHtml(item.type)}</span><span class="criticalBadge"${node.critical ? "" : " hidden"}>Critical path</span></div><div class="beadId">${escapeHtml(item.id)}</div><div class="graphNodeTitle">${escapeHtml(item.title)}</div><div class="graphNodeBadges"><span class="statusBadge status-${escapeHtml(normalizedStatus.replace(/_/g, "-"))}">${escapeHtml(beadStatusLabel(normalizedStatus))}</span><span class="priorityBadge priority-${escapeHtml(normalizedPriority.toLowerCase())}">${escapeHtml(normalizedPriority)}</span>${graphBadges}</div>${dependencyWarning === "" ? "" : `<div class="graphWarning">${escapeHtml(dependencyWarning)}</div>`}${mergeRiskWarning === "" ? "" : `<div class="graphWarning graphMergeRisk">${escapeHtml(mergeRiskWarning)}</div>`}${dependencyLines === "" ? "" : `<div class="graphRelations">${dependencyLines}</div>`}<div class="graphNodeActions"><button class="graphDetailsBead" type="button" data-graph-details-id="${escapeHtml(item.id)}" data-graph-details-workspace="${escapeHtml(workspacePath)}">Details</button>${actionHtml}</div></div>`;
       })
       .join("");
   }).join("");
@@ -379,7 +383,10 @@ function renderBeadsDependencyGraph(
       ? `<details class="graphIssueDrawer dependencyIssueDrawer"><summary><span>Dependency warnings</span><strong>${dependencyWarnings.size}</strong></summary><div class="graphWarningBand">${Array.from(
           dependencyWarnings.entries()
         )
-          .map(([id, message]) => `<span>${escapeHtml(id)}: ${escapeHtml(message)}</span>`)
+          .map(
+            ([id, message]) =>
+              `<span data-warning-id="${escapeHtml(id)}">${escapeHtml(id)}: ${escapeHtml(message)}</span>`
+          )
           .join("")}</div></details>`
       : "";
   const mergeRiskSummary =
@@ -391,17 +398,14 @@ function renderBeadsDependencyGraph(
       ? `<details class="graphIssueDrawer mergeRiskIssueDrawer"><summary><span>Merge/worktree risk</span><strong>${mergeRiskWarnings.size}</strong></summary><div class="graphRiskBand">${Array.from(
           mergeRiskWarnings.entries()
         )
-          .map(([id, message]) => `<span>${escapeHtml(id)}: ${escapeHtml(message)}</span>`)
+          .map(
+            ([id, message]) =>
+              `<span data-risk-id="${escapeHtml(id)}">${escapeHtml(id)}: ${escapeHtml(message)}</span>`
+          )
           .join("")}</div></details>`
       : "";
-  const criticalSummary =
-    graph.criticalPathIds.length > 0
-      ? `<span class="summaryPill criticalSummary" title="${escapeHtml(graph.criticalPathIds.join(" -> "))}">${graph.criticalPathIds.length} critical</span>`
-      : "";
-  const criticalPathHtml =
-    graph.criticalPathIds.length > 0
-      ? `<div class="graphPathStrip"><span>Critical Path</span><strong title="${escapeHtml(graph.criticalPathIds.join(" -> "))}">${escapeHtml(graph.criticalPathIds.join(" -> "))}</strong></div>`
-      : `<div class="graphPathStrip emptyCriticalPath"><span>Critical Path</span><strong>No dependency path yet</strong></div>`;
+  const criticalSummary = `<span class="summaryPill criticalSummary" title="${escapeHtml(graph.criticalPathIds.join(" -> "))}"${graph.criticalPathIds.length > 0 ? "" : " hidden"}>${graph.criticalPathIds.length} critical</span>`;
+  const criticalPathHtml = `<div class="graphPathStrip${graph.criticalPathIds.length > 0 ? "" : " emptyCriticalPath"}"><span>Critical Path</span><strong class="graphPathValue" title="${escapeHtml(graph.criticalPathIds.join(" -> "))}">${graph.criticalPathIds.length > 0 ? escapeHtml(graph.criticalPathIds.join(" -> ")) : "No dependency path yet"}</strong></div>`;
   const graphLegendHtml =
     '<div class="graphLegend"><span class="dependencyLegend">Dependency</span><span class="criticalLegend">Critical path</span><span class="parentLegend">Parent</span><span class="riskLegend">Merge/worktree risk</span></div>';
   const graphIssuesHtml =
@@ -409,7 +413,7 @@ function renderBeadsDependencyGraph(
       ? ""
       : `<div class="graphIssueStack">${dependencyWarningHtml}${mergeRiskHtml}</div>`;
 
-  return `<div class="graphPane" data-workspace-path="${escapeHtml(workspacePath)}"><div class="graphHeader"><div class="workspaceName">Execution Map</div><div class="workspaceSummary"><span class="summaryPill">${graph.edges.length} deps</span>${criticalSummary}${dependencyWarningSummary}${mergeRiskSummary}</div></div>${graphIssuesHtml}<div class="graphMapFrame"><div class="graphMapHeader"><div class="graphMapHeaderMain">${criticalPathHtml}${graphLegendHtml}</div></div><div class="graphScroller"><div class="graphCanvas" data-graph-width="${graphWidth}" data-graph-height="${graphHeight}" style="width:${graphWidth}px;height:${graphHeight}px"><div class="graphContent" style="width:${graphWidth}px;height:${graphHeight}px;--graph-node-width:${GRAPH_NODE_WIDTH}px">${edgeHtml}<svg class="dependencyOverlay" aria-hidden="true"></svg>${levelGuideHtml}<div class="graphNodes">${nodeHtml}</div></div></div><div class="graphZoomSelection" hidden></div></div></div></div>`;
+  return `<div class="graphPane" data-workspace-path="${escapeHtml(workspacePath)}"><div class="graphHeader"><div><div class="workspaceName">Execution Map</div><div class="graphGestureHint">Click, then wheel to zoom · Drag a box to zoom · Shift+drag to pan · Double-click to fit</div></div><div class="graphHeaderActions"><div class="workspaceSummary"><span class="summaryPill dependencySummary">${graph.edges.length} deps</span>${criticalSummary}${dependencyWarningSummary}${mergeRiskSummary}</div><div class="graphControls" role="group" aria-label="Graph zoom controls"><button type="button" data-graph-action="out" title="Zoom out" aria-label="Zoom out">−</button><span class="graphZoomValue" aria-live="polite">100%</span><button type="button" data-graph-action="in" title="Zoom in" aria-label="Zoom in">+</button><button type="button" data-graph-action="fit">Fit</button></div></div></div>${graphIssuesHtml}<div class="graphMapFrame"><div class="graphMapHeader"><div class="graphMapHeaderMain">${criticalPathHtml}${graphLegendHtml}</div></div><div class="graphScroller" tabindex="0" aria-label="Dependency graph. Click to activate wheel zoom. Drag to zoom, Shift drag to pan, arrow keys to pan, and press zero to fit."><div class="graphCanvas" data-graph-width="${graphWidth}" data-graph-height="${graphHeight}" style="width:${graphWidth}px;height:${graphHeight}px"><div class="graphContent" style="width:${graphWidth}px;height:${graphHeight}px;--graph-node-width:${GRAPH_NODE_WIDTH}px">${edgeHtml}<svg class="dependencyOverlay" aria-hidden="true"></svg>${levelGuideHtml}<div class="graphNodes">${nodeHtml}</div></div></div><div class="graphZoomSelection" hidden></div></div></div></div>`;
 }
 
 export function renderBeadsWebviewHtml(
@@ -628,6 +632,7 @@ export function renderBeadsWebviewHtml(
             };
             const treeWidth = depth > 0 ? depth * 18 : 0;
             const childCount = childCountByParent.get(item.id) ?? 0;
+            const detailsId = getBeadDetailsId(group.workspacePath, item.id);
             const initialRowStyle = isDefaultVisibleStatus(normalizedStatus)
               ? ""
               : ' style="display:none"';
@@ -648,7 +653,7 @@ export function renderBeadsWebviewHtml(
               childCount > 0
                 ? `<button class="collapseToggle" type="button" aria-expanded="true" title="Toggle subprojects"><span class="collapseIcon" aria-hidden="true">▾</span></button>`
                 : '<span class="collapseSpacer" aria-hidden="true"></span>';
-            return `<tr class="${rowClasses}"${initialRowStyle} data-id="${escapeHtml(item.id)}" data-workspace-path="${escapeHtml(group.workspacePath)}" data-parent-id="${escapeHtml(parentId ?? "")}" data-epic-id="${escapeHtml(epicId ?? "")}" data-bead-type="${escapeHtml(normalizedType)}" data-depth="${depth}" data-child-count="${childCount}" data-order-index="${orderIndex}" data-guide-columns="${guideColumns.map((value) => (value ? "1" : "0")).join("")}" data-last-sibling="${isLastSibling ? "1" : "0"}" data-status="${escapeHtml(normalizedStatus)}" data-parallelizable="${item.parallelizable ? "1" : "0"}" data-parallel-source="${escapeHtml(item.parallelizableSource)}" data-item="${escapeHtml(encodeURIComponent(JSON.stringify(serializedItem)))}" data-updated-ts="${updatedTs}" data-type-sort="${typeSortOrder}" data-priority-sort="${Number.isNaN(prioritySortOrder) ? 9 : prioritySortOrder}"><td><span class="typeBadge type-${escapeHtml(normalizedType)}">${escapeHtml(item.type)}</span></td><td class="parallelCell">${parallelCell}</td><td><div class="titleCell" style="--tree-width:${treeWidth}px">${hierarchyToggle}<div class="titleContent"><div class="beadId">${escapeHtml(item.id)}</div><div class="beadTitle">${escapeHtml(item.title)}</div>${executionBadges === "" ? "" : `<div class="beadMeta">${executionBadges}</div>`}</div></div></td><td><div class="statusCell"><span class="statusBadge status-${escapeHtml(normalizedStatus.replace(/_/g, "-"))}">${escapeHtml(statusLabel)}</span>${progressLabel === "" ? "" : `<span class="progressText">${escapeHtml(progressLabel)}</span>`}</div></td><td><span class="priorityBadge priority-${escapeHtml(normalizedPriority.toLowerCase())}">${escapeHtml(normalizedPriority)}</span></td><td class="updatedCell" title="${escapeHtml(item.updatedAt)}">${escapeHtml(shortUpdated)}</td></tr>`;
+            return `<tr class="${rowClasses}"${initialRowStyle} data-id="${escapeHtml(item.id)}" data-workspace-path="${escapeHtml(group.workspacePath)}" data-details-id="${escapeHtml(detailsId)}" data-parent-id="${escapeHtml(parentId ?? "")}" data-epic-id="${escapeHtml(epicId ?? "")}" data-bead-type="${escapeHtml(normalizedType)}" data-depth="${depth}" data-child-count="${childCount}" data-order-index="${orderIndex}" data-guide-columns="${guideColumns.map((value) => (value ? "1" : "0")).join("")}" data-last-sibling="${isLastSibling ? "1" : "0"}" data-status="${escapeHtml(normalizedStatus)}" data-parallelizable="${item.parallelizable ? "1" : "0"}" data-parallel-source="${escapeHtml(item.parallelizableSource)}" data-item="${escapeHtml(encodeURIComponent(JSON.stringify(serializedItem)))}" data-updated-ts="${updatedTs}" data-type-sort="${typeSortOrder}" data-priority-sort="${Number.isNaN(prioritySortOrder) ? 9 : prioritySortOrder}"><td><span class="typeBadge type-${escapeHtml(normalizedType)}">${escapeHtml(item.type)}</span></td><td class="parallelCell">${parallelCell}</td><td><div class="titleCell" style="--tree-width:${treeWidth}px">${hierarchyToggle}<div class="titleContent"><div class="beadId">${escapeHtml(item.id)}</div><button class="beadTitle beadDetailsButton" type="button" aria-expanded="false" aria-controls="${escapeHtml(detailsId)}">${escapeHtml(item.title)}</button>${executionBadges === "" ? "" : `<div class="beadMeta">${executionBadges}</div>`}</div></div></td><td><div class="statusCell"><span class="statusBadge status-${escapeHtml(normalizedStatus.replace(/_/g, "-"))}">${escapeHtml(statusLabel)}</span>${progressLabel === "" ? "" : `<span class="progressText">${escapeHtml(progressLabel)}</span>`}</div></td><td><span class="priorityBadge priority-${escapeHtml(normalizedPriority.toLowerCase())}">${escapeHtml(normalizedPriority)}</span></td><td class="updatedCell" title="${escapeHtml(item.updatedAt)}">${escapeHtml(shortUpdated)}</td></tr>`;
           })
           .join("");
         const graphHtml = renderBeadsDependencyGraph(flatItems, group.workspacePath, agentAliases);
@@ -693,6 +698,7 @@ export function renderBeadsWebviewHtml(
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <style>
 body{font-family:var(--vscode-font-family);color:var(--vscode-foreground);padding:6px;background:var(--vscode-editor-background);font-size:13px;}
+[hidden]{display:none!important;}
 .toolbar{display:grid;grid-template-columns:minmax(0,1fr) auto;align-items:start;gap:8px;margin-bottom:6px;padding:6px;border:1px solid var(--vscode-panel-border);border-radius:8px;background:var(--vscode-sideBar-background,var(--vscode-editor-background));box-shadow:0 1px 4px rgba(0,0,0,.12);}
 .toolbarMain{display:flex;align-items:center;gap:6px;flex-wrap:wrap;min-width:0;}
 .toolbarActions{display:flex;align-items:center;justify-content:flex-end;gap:8px;flex:0 0 auto;}
@@ -721,6 +727,7 @@ body{font-family:var(--vscode-font-family);color:var(--vscode-foreground);paddin
 .contextMenu button:disabled{opacity:.45;cursor:default;}
 button{border:1px solid var(--vscode-button-border,transparent);background:var(--vscode-button-background);color:var(--vscode-button-foreground);padding:4px 8px;cursor:pointer;border-radius:6px;font-size:11px;}
 button:hover{background:var(--vscode-button-hoverBackground);}
+button:focus-visible,select:focus-visible,.graphScroller:focus-visible{outline:1px solid var(--vscode-focusBorder);outline-offset:2px;}
 #clearFilters{display:none;}
 .actionBtn{display:inline-flex;align-items:center;justify-content:center;height:24px;padding:0 10px;border-radius:6px;background:rgba(128,128,128,.1);border:1px solid rgba(128,128,128,.5);gap:6px;transition:border-color .18s ease, background-color .18s ease, box-shadow .18s ease;}
 .actionBtn:hover{background:rgba(128,128,128,.2);}
@@ -780,6 +787,8 @@ th:nth-child(1){width:52px;}th:nth-child(2){width:72px;}th:nth-child(4){width:78
 .hierarchyGuideNodeShadow{fill:rgba(0,0,0,.22);vector-effect:non-scaling-stroke;opacity:.4;}
 .hierarchyGuideNode{fill:var(--vscode-textLink-foreground, #4da3ff);vector-effect:non-scaling-stroke;opacity:1;}
 .beadTitle{font-size:13px;font-weight:650;line-height:1.25;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}
+.beadDetailsButton{display:block;width:100%;padding:0;border:none;border-radius:2px;background:transparent;color:inherit;text-align:left;font:inherit;}
+.beadDetailsButton:hover{background:transparent;text-decoration:underline;}
 .beadMeta{display:flex;align-items:center;gap:4px;flex-wrap:wrap;margin-top:4px;}
 .executionBadge{display:inline-flex;align-items:center;max-width:100%;padding:1px 6px;border-radius:6px;border:1px solid rgba(128,128,128,.42);font-size:10px;font-weight:650;line-height:15px;color:var(--vscode-descriptionForeground);background:rgba(128,128,128,.1);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}
 .stateBadge{border-color:rgba(20,184,166,.55);color:var(--vscode-charts-cyan,#14b8a6);background:rgba(20,184,166,.13);}
@@ -834,6 +843,12 @@ th:nth-child(1){width:52px;}th:nth-child(2){width:72px;}th:nth-child(4){width:78
 .detailsDescription{margin-top:8px;padding-top:8px;border-top:1px solid var(--vscode-panel-border);white-space:pre-wrap;line-height:1.45;}
 .graphPane{position:relative;display:flex;flex-direction:column;height:clamp(360px,calc(100vh - 132px),900px);border:1px solid var(--vscode-panel-border);border-radius:8px;background:var(--vscode-editor-background);overflow:hidden;padding:0;}
 .graphHeader{display:flex;align-items:center;justify-content:space-between;gap:8px;margin:0;position:sticky;top:0;left:0;z-index:5;background:var(--vscode-editor-background);padding:10px 12px 8px;border-bottom:1px solid var(--vscode-panel-border);}
+.graphHeaderActions{display:flex;align-items:center;justify-content:flex-end;gap:8px;flex-wrap:wrap;}
+.graphGestureHint{margin-top:2px;color:var(--vscode-descriptionForeground);font-size:10px;line-height:1.3;}
+.graphControls{display:inline-flex;align-items:center;gap:2px;border:1px solid var(--vscode-panel-border);border-radius:6px;padding:2px;background:rgba(128,128,128,.08);}
+.graphControls button{min-width:24px;height:22px;padding:0 6px;background:transparent;color:var(--vscode-foreground);}
+.graphControls button:hover{background:rgba(128,128,128,.18);}
+.graphZoomValue{min-width:38px;text-align:center;color:var(--vscode-descriptionForeground);font-size:10px;font-variant-numeric:tabular-nums;}
 .criticalSummary{border-color:rgba(236,72,153,.5);color:var(--vscode-charts-pink,#ec4899);}
 .dependencyWarningSummary{border-color:rgba(245,158,11,.55);color:var(--vscode-editorWarning-foreground,#f59e0b);}
 .mergeRiskSummary{border-color:rgba(239,68,68,.55);color:var(--vscode-errorForeground,#ef4444);}
@@ -867,7 +882,8 @@ th:nth-child(1){width:52px;}th:nth-child(2){width:72px;}th:nth-child(4){width:78
 .graphWarningBand span{display:inline-flex;align-items:center;min-height:18px;padding:1px 6px;border-radius:6px;border:1px solid rgba(245,158,11,.5);background:rgba(245,158,11,.12);color:var(--vscode-editorWarning-foreground,#f59e0b);font-size:10px;font-weight:650;}
 .graphRiskBand{display:flex;flex-wrap:wrap;gap:4px;margin:0;padding:0 8px 8px;max-height:92px;overflow:auto;}
 .graphRiskBand span{display:inline-flex;align-items:center;min-height:18px;padding:1px 6px;border-radius:6px;border:1px solid rgba(239,68,68,.5);background:rgba(239,68,68,.12);color:var(--vscode-errorForeground,#ef4444);font-size:10px;font-weight:650;}
-.graphScroller{position:relative;flex:1 1 auto;min-height:0;overflow:hidden;overscroll-behavior:contain;background:var(--vscode-editor-background);cursor:crosshair;user-select:none;}
+.graphScroller{position:relative;flex:1 1 auto;min-height:0;overflow:hidden;background:var(--vscode-editor-background);cursor:crosshair;user-select:none;}
+.graphScroller.isPanning{cursor:grabbing;}
 .graphCanvas{position:relative;min-width:100%;min-height:100%;overflow:hidden;background-color:var(--vscode-editor-background);background-image:linear-gradient(rgba(128,128,128,.1) 1px, transparent 1px),linear-gradient(90deg, rgba(128,128,128,.1) 1px, transparent 1px);background-size:48px 48px;}
 .graphContent{position:absolute;left:0;top:0;transform:translate(var(--graph-pan-x,0px),var(--graph-pan-y,0px)) scale(var(--graph-zoom,1));transform-origin:0 0;}
 .graphZoomSelection{position:absolute;z-index:6;border:1px solid var(--vscode-focusBorder,#3b82f6);background:rgba(59,130,246,.16);box-shadow:0 0 0 1px rgba(59,130,246,.18) inset;pointer-events:none;}
@@ -881,12 +897,13 @@ th:nth-child(1){width:52px;}th:nth-child(2){width:72px;}th:nth-child(4){width:78
 .graphLevelLabel strong{font-size:11px;font-weight:800;line-height:1.1;color:var(--vscode-foreground);}
 .graphLevelLabel small{font-size:10px;font-weight:650;line-height:1.15;color:var(--vscode-descriptionForeground);}
 .graphNodes{position:absolute;inset:0;z-index:2;}
-.graphNode{position:absolute;left:var(--graph-x);top:var(--graph-y);width:var(--graph-node-width,280px);border:1px solid var(--vscode-panel-border);border-radius:8px;background:var(--vscode-sideBar-background,var(--vscode-editor-background));padding:8px;box-shadow:0 1px 3px rgba(0,0,0,.12);}
+.graphNode{box-sizing:border-box;position:absolute;left:var(--graph-x);top:var(--graph-y);width:var(--graph-node-width,280px);border:1px solid var(--vscode-panel-border);border-radius:8px;background:var(--vscode-sideBar-background,var(--vscode-editor-background));padding:8px;box-shadow:0 1px 3px rgba(0,0,0,.12);}
 .graphNode.criticalGraphNode{border-color:rgba(236,72,153,.62);box-shadow:inset 3px 0 0 var(--vscode-charts-pink,#ec4899), 0 1px 3px rgba(0,0,0,.12);}
 .graphNode.dependencyWarningGraphNode{border-color:rgba(245,158,11,.58);box-shadow:inset 3px 0 0 var(--vscode-editorWarning-foreground,#f59e0b), 0 1px 3px rgba(0,0,0,.12);}
 .graphNode.mergeRiskGraphNode{border-color:rgba(239,68,68,.58);box-shadow:inset 3px 0 0 var(--vscode-errorForeground,#ef4444), 0 1px 3px rgba(0,0,0,.12);}
 .graphNodeTop{display:flex;align-items:center;justify-content:space-between;gap:6px;margin-bottom:5px;}
 .criticalBadge{display:inline-flex;align-items:center;min-height:17px;padding:1px 6px;border-radius:999px;border:1px solid rgba(236,72,153,.55);background:rgba(236,72,153,.14);color:var(--vscode-charts-pink,#ec4899);font-size:10px;font-weight:750;white-space:nowrap;}
+.criticalBadge[hidden]{display:none;}
 .graphNodeTitle{font-size:12px;font-weight:700;line-height:1.3;margin:2px 0 7px;overflow-wrap:anywhere;}
 .graphNodeBadges{display:flex;align-items:center;gap:4px;flex-wrap:wrap;}
 .graphWarning{margin-top:7px;padding:5px 6px;border-radius:6px;border:1px solid rgba(245,158,11,.5);background:rgba(245,158,11,.12);color:var(--vscode-editorWarning-foreground,#f59e0b);font-size:10px;font-weight:650;line-height:1.35;}
@@ -894,8 +911,10 @@ th:nth-child(1){width:52px;}th:nth-child(2){width:72px;}th:nth-child(4){width:78
 .graphRelations{display:grid;gap:3px;margin-top:7px;padding-top:7px;border-top:1px solid var(--vscode-panel-border);}
 .graphRelation{display:grid;grid-template-columns:54px minmax(0,1fr);gap:5px;font-size:10px;color:var(--vscode-descriptionForeground);line-height:1.35;}
 .graphRelation span{font-weight:700;color:var(--vscode-foreground);}
+.graphRelationValue{font:inherit;font-weight:400;overflow-wrap:anywhere;}
 .graphParentRelation{border-left:2px dashed var(--vscode-textLink-foreground,#3b82f6);padding-left:5px;}
-.graphNodeActions{position:relative;z-index:3;display:flex;justify-content:flex-end;margin-top:8px;}
+.graphNodeActions{position:relative;z-index:3;display:flex;justify-content:flex-end;gap:6px;margin-top:8px;}
+.graphDetailsBead{height:24px;padding:0 8px;background:transparent;color:var(--vscode-foreground);border-color:var(--vscode-panel-border);}
 .assignStartBead,.mergeParallelPrs{height:24px;padding:0 8px;font-weight:650;}
 .mergeParallelPrs{border-color:rgba(249,115,22,.55);background:rgba(249,115,22,.16);color:var(--vscode-charts-orange,#f97316);}
 .assignStartBead:disabled{opacity:.45;cursor:default;}
@@ -927,6 +946,7 @@ th:nth-child(1){width:52px;}th:nth-child(2){width:72px;}th:nth-child(4){width:78
   .detailsGrid{grid-template-columns:82px minmax(0,1fr);}
   .graphPane{height:clamp(320px,calc(100vh - 118px),820px);padding:8px;}
   .graphHeader{position:relative;padding:8px;margin:-8px -8px 0;}
+  .graphHeaderActions{justify-content:flex-start;}
   .graphIssueStack{padding:8px 0 0;}
   .graphMapFrame{margin:8px 0 0;}
   .graphMapHeader{align-items:start;}
@@ -979,7 +999,7 @@ code{font-family:var(--vscode-editor-font-family);}
   </div>
 </div>
 <div class="toolbarStatsRow"><div class="stats" id="stats"></div></div>
-<div id="rowContextMenu" class="contextMenu"><button id="createBeadAction" type="button">Create</button><button id="closeBeadAction" type="button">Close</button></div>
+<div id="rowContextMenu" class="contextMenu" role="menu"><button id="createBeadAction" type="button" role="menuitem">Create</button><button id="closeBeadAction" type="button" role="menuitem">Close</button></div>
 ${bodyHtml}
 ${warningHtml}
 ${errorHtml}

--- a/src/beadsWebview.ts
+++ b/src/beadsWebview.ts
@@ -409,7 +409,7 @@ function renderBeadsDependencyGraph(
       ? ""
       : `<div class="graphIssueStack">${dependencyWarningHtml}${mergeRiskHtml}</div>`;
 
-  return `<div class="graphPane" data-workspace-path="${escapeHtml(workspacePath)}"><div class="graphHeader"><div class="workspaceName">Execution Map</div><div class="workspaceSummary"><span class="summaryPill">${graph.edges.length} deps</span>${criticalSummary}${dependencyWarningSummary}${mergeRiskSummary}</div></div>${graphIssuesHtml}<div class="graphMapFrame"><div class="graphMapHeader"><div class="graphMapHeaderMain">${criticalPathHtml}${graphLegendHtml}</div></div><div class="graphScroller"><div class="graphCanvas" data-graph-width="${graphWidth}" data-graph-height="${graphHeight}" style="width:${graphWidth}px;height:${graphHeight}px"><div class="graphContent" style="width:${graphWidth}px;height:${graphHeight}px;--graph-node-width:${GRAPH_NODE_WIDTH}px">${edgeHtml}<svg class="dependencyOverlay" aria-hidden="true"></svg>${levelGuideHtml}<div class="graphNodes">${nodeHtml}</div></div></div></div></div></div>`;
+  return `<div class="graphPane" data-workspace-path="${escapeHtml(workspacePath)}"><div class="graphHeader"><div class="workspaceName">Execution Map</div><div class="workspaceSummary"><span class="summaryPill">${graph.edges.length} deps</span>${criticalSummary}${dependencyWarningSummary}${mergeRiskSummary}</div></div>${graphIssuesHtml}<div class="graphMapFrame"><div class="graphMapHeader"><div class="graphMapHeaderMain">${criticalPathHtml}${graphLegendHtml}</div></div><div class="graphScroller"><div class="graphCanvas" data-graph-width="${graphWidth}" data-graph-height="${graphHeight}" style="width:${graphWidth}px;height:${graphHeight}px"><div class="graphContent" style="width:${graphWidth}px;height:${graphHeight}px;--graph-node-width:${GRAPH_NODE_WIDTH}px">${edgeHtml}<svg class="dependencyOverlay" aria-hidden="true"></svg>${levelGuideHtml}<div class="graphNodes">${nodeHtml}</div></div></div><div class="graphZoomSelection" hidden></div></div></div></div>`;
 }
 
 export function renderBeadsWebviewHtml(
@@ -867,9 +867,10 @@ th:nth-child(1){width:52px;}th:nth-child(2){width:72px;}th:nth-child(4){width:78
 .graphWarningBand span{display:inline-flex;align-items:center;min-height:18px;padding:1px 6px;border-radius:6px;border:1px solid rgba(245,158,11,.5);background:rgba(245,158,11,.12);color:var(--vscode-editorWarning-foreground,#f59e0b);font-size:10px;font-weight:650;}
 .graphRiskBand{display:flex;flex-wrap:wrap;gap:4px;margin:0;padding:0 8px 8px;max-height:92px;overflow:auto;}
 .graphRiskBand span{display:inline-flex;align-items:center;min-height:18px;padding:1px 6px;border-radius:6px;border:1px solid rgba(239,68,68,.5);background:rgba(239,68,68,.12);color:var(--vscode-errorForeground,#ef4444);font-size:10px;font-weight:650;}
-.graphScroller{flex:1 1 auto;min-height:0;overflow:hidden;overscroll-behavior:contain;background:var(--vscode-editor-background);}
+.graphScroller{position:relative;flex:1 1 auto;min-height:0;overflow:hidden;overscroll-behavior:contain;background:var(--vscode-editor-background);cursor:crosshair;user-select:none;}
 .graphCanvas{position:relative;min-width:100%;min-height:100%;overflow:hidden;background-color:var(--vscode-editor-background);background-image:linear-gradient(rgba(128,128,128,.1) 1px, transparent 1px),linear-gradient(90deg, rgba(128,128,128,.1) 1px, transparent 1px);background-size:48px 48px;}
-.graphContent{position:absolute;left:0;top:0;transform:scale(var(--graph-zoom,1));transform-origin:0 0;}
+.graphContent{position:absolute;left:0;top:0;transform:translate(var(--graph-pan-x,0px),var(--graph-pan-y,0px)) scale(var(--graph-zoom,1));transform-origin:0 0;}
+.graphZoomSelection{position:absolute;z-index:6;border:1px solid var(--vscode-focusBorder,#3b82f6);background:rgba(59,130,246,.16);box-shadow:0 0 0 1px rgba(59,130,246,.18) inset;pointer-events:none;}
 .dependencyOverlay{position:absolute;inset:0;z-index:1;width:100%;height:100%;pointer-events:none;overflow:visible;}
 .dependencyPath{fill:none;stroke:rgba(148,163,184,.8);stroke-width:1.4;stroke-linecap:round;stroke-linejoin:round;vector-effect:non-scaling-stroke;}
 .dependencyPath.criticalDependencyPath{stroke:var(--vscode-charts-pink,#ec4899);stroke-width:2;}

--- a/tests/beadsGraphModel.test.ts
+++ b/tests/beadsGraphModel.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  computePackedGraphLayout,
+  computeVisibleGraphState,
+  graphEdgeKey
+} from "../web/beadsGraphModel";
+
+describe("visible beads graph state", () => {
+  it("recomputes the critical path after filtered nodes disappear", () => {
+    const edges = [
+      { fromId: "closed", toId: "middle" },
+      { fromId: "middle", toId: "last" },
+      { fromId: "ready", toId: "last" }
+    ];
+
+    const state = computeVisibleGraphState(["middle", "ready", "last"], edges);
+
+    expect(state.edges).toEqual([
+      { fromId: "middle", toId: "last" },
+      { fromId: "ready", toId: "last" }
+    ]);
+    expect(state.criticalPathIds).toEqual(["middle", "last"]);
+    expect(state.criticalEdgeKeys).toEqual(new Set([graphEdgeKey("middle", "last")]));
+    expect(state.levelsById).toEqual(
+      new Map([
+        ["middle", 0],
+        ["ready", 0],
+        ["last", 1]
+      ])
+    );
+  });
+
+  it("does not report isolated nodes as a dependency path", () => {
+    expect(computeVisibleGraphState(["ready"], []).criticalPathIds).toEqual([]);
+  });
+});
+
+describe("beads graph layout", () => {
+  it("stacks variable-height cards without overlap", () => {
+    const layout = computePackedGraphLayout(
+      [
+        { id: "short", level: 0, height: 100 },
+        { id: "tall", level: 0, height: 260 },
+        { id: "next", level: 0, height: 120 }
+      ],
+      {
+        nodeWidth: 252,
+        levelGap: 56,
+        columnGap: 24,
+        laneGap: 30,
+        paddingX: 28,
+        paddingY: 44
+      }
+    );
+    const short = layout.nodes.find((node) => node.id === "short");
+    const tall = layout.nodes.find((node) => node.id === "tall");
+
+    expect(short).toEqual({ id: "short", x: 28, y: 44 });
+    expect(tall).toEqual({ id: "tall", x: 28, y: 174 });
+    expect(layout.height).toBeGreaterThanOrEqual(478);
+  });
+});

--- a/tests/beadsWebviewMetadata.test.ts
+++ b/tests/beadsWebviewMetadata.test.ts
@@ -51,9 +51,10 @@ describe("beads webview presentation metadata", () => {
     expect(beadsWebview).toContain("No dependency path yet");
     expect(beadsWebview).toContain("graphIssueDrawer");
     expect(beadsWebview).toContain("graphIssueStack");
-    expect(beadsWebview).not.toContain("graphControls");
-    expect(beadsWebview).not.toContain("data-graph-zoom-action");
-    expect(beadsWebview).not.toContain("graphZoomReset");
+    expect(beadsWebview).toContain("graphControls");
+    expect(beadsWebview).toContain('data-graph-action="out"');
+    expect(beadsWebview).toContain('data-graph-action="fit"');
+    expect(beadsWebview).toContain("graphGestureHint");
     expect(beadsWebview).toContain("graphScroller");
     expect(beadsWebview).toContain("graphContent");
     expect(beadsWebview).toContain("data-graph-width");
@@ -98,6 +99,7 @@ describe("beads webview presentation metadata", () => {
       ".graphScroller{position:relative;flex:1 1 auto;min-height:0;overflow:hidden;"
     );
     expect(beadsWebview).not.toContain("scrollbar-gutter:stable");
+    expect(beadsWebview).not.toContain("overscroll-behavior:contain");
     expect(beadsWebview).toContain(
       ".graphCanvas{position:relative;min-width:100%;min-height:100%;overflow:hidden;"
     );
@@ -136,8 +138,10 @@ describe("beads webview presentation metadata", () => {
     expect(beadsMain).toContain("getState(): BeadsWebviewState | undefined");
     expect(beadsMain).toContain("setState(state: BeadsWebviewState): void");
     expect(beadsMain).toContain("normalizeViewMode(vscode.getState()?.viewMode)");
-    expect(beadsMain).toContain("normalizeGraphZoom(vscode.getState()?.graphZoom)");
-    expect(beadsMain).toContain("normalizeGraphPan(vscode.getState()?.graphPan)");
+    expect(beadsMain).toContain("normalizeGraphTransforms(vscode.getState())");
+    expect(beadsMain).toContain("graphTransforms");
+    expect(beadsMain).toContain("getGraphTransform");
+    expect(beadsMain).toContain("saveGraphTransforms");
     expect(beadsMain).toContain("saveViewMode(mode)");
     expect(beadsMain).toContain("saveWebviewState");
     expect(beadsMain).toContain("saveGraphScroll");
@@ -159,8 +163,9 @@ describe("beads webview presentation metadata", () => {
       `canvas.style.height = \`${interpolationStart}viewport.height}px\``
     );
     expect(beadsMain).toContain("zoomGraphFromWheel");
-    expect(beadsMain).not.toContain("event.ctrlKey");
-    expect(beadsMain).not.toContain("event.metaKey");
+    expect(beadsMain).toContain("document.activeElement !== scroller");
+    expect(beadsMain).toContain("event.ctrlKey");
+    expect(beadsMain).toContain("event.metaKey");
     expect(beadsMain).toContain('addEventListener("wheel"');
     expect(beadsMain).toContain('addEventListener("pointerdown"');
     expect(beadsMain).toContain('addEventListener("dblclick"');
@@ -194,7 +199,19 @@ describe("beads webview presentation metadata", () => {
     expect(beadsMain).toContain('scroller?.addEventListener("scroll"');
     expect(beadsMain).not.toContain("saveGraphScroll(pane);\n    renderDependencyGraphOverlays();");
     expect(beadsMain).toContain("content.style.setProperty");
-    expect(beadsMain).not.toContain("data-graph-zoom-action");
+    expect(beadsMain).toContain("data-graph-action");
+    expect(beadsMain).toContain("refreshGraphDerivedState");
+    expect(beadsMain).toContain("computeVisibleGraphState");
+    expect(beadsMain).toContain("layoutGraphPane");
+    expect(beadsMain).toContain("computePackedGraphLayout");
+    expect(beadsMain).toContain("node.offsetHeight");
+    expect(beadsMain).toContain("beginGraphPan");
+    expect(beadsMain).toContain("handleGraphKeydown");
+    expect(beadsMain).toContain("window.innerWidth - menuRect.width");
+    expect(beadsMain).toContain("window.innerHeight - menuRect.height");
+    expect(beadsWebview).toContain("beadDetailsButton");
+    expect(beadsWebview).toContain("graphDetailsBead");
+    expect(beadsWebview).toContain("aria-expanded");
     expect(beadsMain).toContain('command: "assignStartBead"');
     expect(beadsMain).toContain('command: "startParallelBeads"');
     expect(beadsMain).toContain("detailsCell.colSpan = 6");

--- a/tests/beadsWebviewMetadata.test.ts
+++ b/tests/beadsWebviewMetadata.test.ts
@@ -94,11 +94,16 @@ describe("beads webview presentation metadata", () => {
     expect(beadsWebview).toContain("initialDisplay");
     expect(beadsWebview).toContain("--graph-x");
     expect(beadsWebview).toContain("height:clamp(360px,calc(100vh - 132px),900px)");
-    expect(beadsWebview).toContain(".graphScroller{flex:1 1 auto;min-height:0;overflow:hidden;");
+    expect(beadsWebview).toContain(
+      ".graphScroller{position:relative;flex:1 1 auto;min-height:0;overflow:hidden;"
+    );
     expect(beadsWebview).not.toContain("scrollbar-gutter:stable");
     expect(beadsWebview).toContain(
       ".graphCanvas{position:relative;min-width:100%;min-height:100%;overflow:hidden;"
     );
+    expect(beadsWebview).toContain("graphZoomSelection");
+    expect(beadsWebview).toContain("cursor:crosshair");
+    expect(beadsWebview).toContain("translate(var(--graph-pan-x,0px),var(--graph-pan-y,0px))");
     expect(beadsWebview).not.toContain("min-height:620px");
     expect(beadsWebview).not.toContain("min-height:560px");
     expect(beadsWebview).toContain("#clearFilters{display:none;}");
@@ -132,10 +137,14 @@ describe("beads webview presentation metadata", () => {
     expect(beadsMain).toContain("setState(state: BeadsWebviewState): void");
     expect(beadsMain).toContain("normalizeViewMode(vscode.getState()?.viewMode)");
     expect(beadsMain).toContain("normalizeGraphZoom(vscode.getState()?.graphZoom)");
+    expect(beadsMain).toContain("normalizeGraphPan(vscode.getState()?.graphPan)");
     expect(beadsMain).toContain("saveViewMode(mode)");
     expect(beadsMain).toContain("saveWebviewState");
     expect(beadsMain).toContain("saveGraphScroll");
     expect(beadsMain).toContain("setGraphZoom");
+    expect(beadsMain).toContain("beginGraphSelection");
+    expect(beadsMain).toContain("zoomGraphToSelection");
+    expect(beadsMain).toContain("GRAPH_SELECTION_MIN_SIZE");
     expect(beadsMain).toContain("GRAPH_ZOOM_MIN");
     expect(beadsMain).toContain("const GRAPH_ZOOM_MIN = 0.05");
     expect(beadsMain).toContain("GRAPH_ZOOM_MAX");
@@ -153,6 +162,8 @@ describe("beads webview presentation metadata", () => {
     expect(beadsMain).not.toContain("event.ctrlKey");
     expect(beadsMain).not.toContain("event.metaKey");
     expect(beadsMain).toContain('addEventListener("wheel"');
+    expect(beadsMain).toContain('addEventListener("pointerdown"');
+    expect(beadsMain).toContain('addEventListener("dblclick"');
     expect(beadsMain).toContain("passive: false");
     expect(beadsMain).toContain("event.preventDefault()");
     expect(beadsMain).toContain("normalizeOptionalDatasetValue");

--- a/web/beadsGraphModel.ts
+++ b/web/beadsGraphModel.ts
@@ -1,0 +1,176 @@
+export interface VisibleGraphEdge {
+  fromId: string;
+  toId: string;
+}
+
+export interface VisibleGraphState {
+  edges: VisibleGraphEdge[];
+  levelsById: Map<string, number>;
+  criticalPathIds: string[];
+  criticalEdgeKeys: Set<string>;
+}
+
+export interface GraphLayoutNode {
+  id: string;
+  level: number;
+  height: number;
+}
+
+export interface GraphLayoutOptions {
+  nodeWidth: number;
+  levelGap: number;
+  columnGap: number;
+  laneGap: number;
+  paddingX: number;
+  paddingY: number;
+}
+
+export interface GraphLayoutResult {
+  width: number;
+  height: number;
+  nodes: Array<{ id: string; x: number; y: number }>;
+  levels: Array<{ level: number; centerX: number }>;
+}
+
+export function graphEdgeKey(fromId: string, toId: string) {
+  return `${fromId}\0${toId}`;
+}
+
+export function computeVisibleGraphState(
+  nodeIds: Iterable<string>,
+  candidateEdges: Iterable<VisibleGraphEdge>
+): VisibleGraphState {
+  const visibleIds = new Set(nodeIds);
+  const edges = Array.from(candidateEdges).filter(
+    (edge) => visibleIds.has(edge.fromId) && visibleIds.has(edge.toId)
+  );
+  const incomingById = new Map<string, string[]>();
+  for (const id of visibleIds) {
+    incomingById.set(id, []);
+  }
+  for (const edge of edges) {
+    incomingById.get(edge.toId)?.push(edge.fromId);
+  }
+  for (const incoming of incomingById.values()) {
+    incoming.sort((left, right) => left.localeCompare(right));
+  }
+
+  const levelCache = new Map<string, number>();
+  const resolveLevel = (id: string, visiting: Set<string>): number => {
+    const cached = levelCache.get(id);
+    if (cached !== undefined) {
+      return cached;
+    }
+    if (visiting.has(id)) {
+      return 0;
+    }
+
+    visiting.add(id);
+    const incoming = incomingById.get(id) ?? [];
+    const level =
+      incoming.length === 0
+        ? 0
+        : Math.max(...incoming.map((parentId) => resolveLevel(parentId, visiting) + 1));
+    visiting.delete(id);
+    levelCache.set(id, level);
+    return level;
+  };
+  const levelsById = new Map(
+    Array.from(visibleIds, (id) => [id, resolveLevel(id, new Set<string>())] as const)
+  );
+
+  const pathCache = new Map<string, string[]>();
+  const resolveLongestPath = (id: string, visiting: Set<string>): string[] => {
+    const cached = pathCache.get(id);
+    if (cached !== undefined) {
+      return cached;
+    }
+    if (visiting.has(id)) {
+      return [];
+    }
+
+    visiting.add(id);
+    const prefixes = (incomingById.get(id) ?? [])
+      .map((parentId) => resolveLongestPath(parentId, visiting))
+      .sort(
+        (left, right) => right.length - left.length || left.join("|").localeCompare(right.join("|"))
+      );
+    visiting.delete(id);
+    const path = prefixes.length > 0 ? [...prefixes[0], id] : [id];
+    pathCache.set(id, path);
+    return path;
+  };
+
+  const criticalPathIds =
+    edges.length === 0
+      ? []
+      : (Array.from(visibleIds)
+          .map((id) => resolveLongestPath(id, new Set<string>()))
+          .sort(
+            (left, right) =>
+              right.length - left.length || left.join("|").localeCompare(right.join("|"))
+          )[0] ?? []);
+  const criticalEdgeKeys = new Set<string>();
+  for (let index = 1; index < criticalPathIds.length; index += 1) {
+    criticalEdgeKeys.add(graphEdgeKey(criticalPathIds[index - 1], criticalPathIds[index]));
+  }
+
+  return { edges, levelsById, criticalPathIds, criticalEdgeKeys };
+}
+
+export function computePackedGraphLayout(
+  inputNodes: GraphLayoutNode[],
+  options: GraphLayoutOptions
+): GraphLayoutResult {
+  const nodesByLevel = new Map<number, GraphLayoutNode[]>();
+  for (const node of inputNodes) {
+    const nodes = nodesByLevel.get(node.level) ?? [];
+    nodes.push(node);
+    nodesByLevel.set(node.level, nodes);
+  }
+
+  const levels = [...nodesByLevel.keys()].sort((left, right) => left - right);
+  const positionedNodes: GraphLayoutResult["nodes"] = [];
+  const positionedLevels: GraphLayoutResult["levels"] = [];
+  let nextLevelX = options.paddingX;
+  let graphHeight = options.paddingY * 2;
+
+  for (const level of levels) {
+    const nodes = nodesByLevel.get(level) ?? [];
+    const rowCount = Math.max(1, Math.ceil(Math.sqrt(nodes.length)));
+    const columnCount = Math.max(1, Math.ceil(nodes.length / rowCount));
+    const levelWidth =
+      columnCount * options.nodeWidth + Math.max(0, columnCount - 1) * options.columnGap;
+    let levelHeight = options.paddingY * 2;
+
+    for (let column = 0; column < columnCount; column += 1) {
+      let nextY = options.paddingY;
+      const columnNodes = nodes.slice(column * rowCount, (column + 1) * rowCount);
+      for (const node of columnNodes) {
+        positionedNodes.push({
+          id: node.id,
+          x: nextLevelX + column * (options.nodeWidth + options.columnGap),
+          y: nextY
+        });
+        nextY += Math.max(1, node.height) + options.laneGap;
+      }
+      if (columnNodes.length > 0) {
+        nextY -= options.laneGap;
+      }
+      levelHeight = Math.max(levelHeight, nextY + options.paddingY);
+    }
+
+    positionedLevels.push({ level, centerX: nextLevelX + levelWidth / 2 });
+    graphHeight = Math.max(graphHeight, levelHeight);
+    nextLevelX += levelWidth + options.levelGap;
+  }
+
+  const graphWidth =
+    levels.length === 0 ? options.paddingX * 2 : nextLevelX - options.levelGap + options.paddingX;
+  return {
+    width: Math.max(1, graphWidth),
+    height: Math.max(1, graphHeight),
+    nodes: positionedNodes,
+    levels: positionedLevels
+  };
+}

--- a/web/beadsMain.ts
+++ b/web/beadsMain.ts
@@ -13,10 +13,20 @@ type ViewMode = "table" | "graph";
 type BeadRow = HTMLTableRowElement & { dataset: DOMStringMap };
 type BeadSection = HTMLElement & { dataset: DOMStringMap };
 type GraphScrollState = { left: number; top: number };
+type GraphPanState = { x: number; y: number };
 type GraphZoomAnchor = { pane: HTMLElement; clientX: number; clientY: number };
+type GraphSelectionState = {
+  pane: HTMLElement;
+  pointerId: number;
+  startX: number;
+  startY: number;
+  currentX: number;
+  currentY: number;
+};
 type BeadsWebviewState = {
   viewMode?: ViewMode;
   graphZoom?: number;
+  graphPan?: GraphPanState;
   graphScroll?: Record<string, GraphScrollState>;
   [key: string]: unknown;
 };
@@ -67,6 +77,7 @@ const ALL_FILTERS: StatusFilter[] = ["open", "in_progress", "blocked", "closed",
 const GRAPH_ZOOM_MIN = 0.05;
 const GRAPH_ZOOM_MAX = 1.8;
 const GRAPH_FIT_PADDING = 16;
+const GRAPH_SELECTION_MIN_SIZE = 12;
 const PRESET_FILTERS: Record<string, StatusFilter[]> = {
   default: ["open", "in_progress", "blocked"],
   open: ["open"],
@@ -84,6 +95,8 @@ let contextMenuWorkspacePath = "";
 let sortState: { key: SortKey; desc: boolean } = { key: "order", desc: false };
 let activeViewMode: ViewMode = normalizeViewMode(vscode.getState()?.viewMode);
 let graphZoom = normalizeGraphZoom(vscode.getState()?.graphZoom);
+let graphPan = normalizeGraphPan(vscode.getState()?.graphPan);
+let graphSelection: GraphSelectionState | null = null;
 let rowClickTimer: number | null = null;
 const collapsedIds = new Set<string>();
 const collapsedEpicIds = new Set<string>();
@@ -122,6 +135,18 @@ function normalizeViewMode(value: unknown): ViewMode {
 function normalizeGraphZoom(value: unknown) {
   const numericValue = typeof value === "number" && Number.isFinite(value) ? value : 1;
   return Math.min(GRAPH_ZOOM_MAX, Math.max(GRAPH_ZOOM_MIN, numericValue));
+}
+
+function normalizeGraphPan(value: unknown): GraphPanState {
+  if (typeof value !== "object" || value === null) {
+    return { x: 0, y: 0 };
+  }
+
+  const candidate = value as { x?: unknown; y?: unknown };
+  return {
+    x: typeof candidate.x === "number" && Number.isFinite(candidate.x) ? candidate.x : 0,
+    y: typeof candidate.y === "number" && Number.isFinite(candidate.y) ? candidate.y : 0
+  };
 }
 
 function saveWebviewState(patch: Partial<BeadsWebviewState>) {
@@ -781,6 +806,10 @@ function getGraphContent(pane: HTMLElement) {
   return pane.querySelector<HTMLElement>(".graphContent");
 }
 
+function getGraphSelectionBox(pane: HTMLElement) {
+  return pane.querySelector<HTMLElement>(".graphZoomSelection");
+}
+
 function getGraphWorkspaceKey(pane: HTMLElement) {
   return pane.dataset.workspacePath || "default";
 }
@@ -814,7 +843,29 @@ function getGraphRequiredSize(pane: HTMLElement, base: { width: number; height: 
 }
 
 function saveGraphZoom() {
-  saveWebviewState({ graphZoom });
+  saveWebviewState({ graphZoom, graphPan });
+}
+
+function clampGraphPanForPane(pane: HTMLElement, pan: GraphPanState) {
+  const scroller = getGraphScroller(pane);
+  const canvas = getGraphCanvas(pane);
+  if (scroller === null || canvas === null) {
+    return pan;
+  }
+
+  const viewport = getGraphViewportSize(scroller);
+  const requiredSize = getGraphRequiredSize(pane, getGraphBaseSize(canvas));
+  const scaledWidth = requiredSize.width * graphZoom;
+  const scaledHeight = requiredSize.height * graphZoom;
+  const minX = Math.min(0, viewport.width - scaledWidth);
+  const minY = Math.min(0, viewport.height - scaledHeight);
+  const maxX = scaledWidth <= viewport.width ? (viewport.width - scaledWidth) / 2 : 0;
+  const maxY = scaledHeight <= viewport.height ? (viewport.height - scaledHeight) / 2 : 0;
+
+  return {
+    x: Math.min(maxX, Math.max(minX, pan.x)),
+    y: Math.min(maxY, Math.max(minY, pan.y))
+  };
 }
 
 function saveGraphScroll(pane: HTMLElement) {
@@ -846,6 +897,8 @@ function applyGraphZoomToPane(pane: HTMLElement) {
   canvas.style.width = `${viewport.width}px`;
   canvas.style.height = `${viewport.height}px`;
   content.style.setProperty("--graph-zoom", graphZoom.toFixed(2));
+  content.style.setProperty("--graph-pan-x", `${graphPan.x.toFixed(1)}px`);
+  content.style.setProperty("--graph-pan-y", `${graphPan.y.toFixed(1)}px`);
 }
 
 function applyGraphZoomToAll() {
@@ -887,6 +940,14 @@ function fitGraphToViewport() {
   }
 
   graphZoom = nextZoom;
+  graphPan = { x: 0, y: 0 };
+  for (const pane of Array.from(document.querySelectorAll<HTMLElement>(".graphPane"))) {
+    if (pane.offsetParent === null) {
+      continue;
+    }
+    graphPan = clampGraphPanForPane(pane, graphPan);
+    break;
+  }
   applyGraphZoomToAll();
   for (const pane of Array.from(document.querySelectorAll<HTMLElement>(".graphPane"))) {
     const scroller = getGraphScroller(pane);
@@ -907,48 +968,30 @@ function setGraphZoom(nextZoom: number, anchor?: GraphZoomAnchor) {
     return;
   }
 
-  const anchors = new Map<
-    HTMLElement,
-    { x: number; y: number; offsetX: number; offsetY: number }
-  >();
-  for (const pane of Array.from(document.querySelectorAll<HTMLElement>(".graphPane"))) {
-    const scroller = getGraphScroller(pane);
-    if (scroller === null) {
-      continue;
-    }
-    if (anchor !== undefined && anchor.pane === pane) {
-      const rect = scroller.getBoundingClientRect();
-      const offsetX = anchor.clientX - rect.left;
-      const offsetY = anchor.clientY - rect.top;
-      anchors.set(pane, {
-        x: (scroller.scrollLeft + offsetX) / previousZoom,
-        y: (scroller.scrollTop + offsetY) / previousZoom,
-        offsetX,
-        offsetY
-      });
-    } else {
-      const offsetX = scroller.clientWidth / 2;
-      const offsetY = scroller.clientHeight / 2;
-      anchors.set(pane, {
-        x: (scroller.scrollLeft + offsetX) / previousZoom,
-        y: (scroller.scrollTop + offsetY) / previousZoom,
-        offsetX,
-        offsetY
-      });
-    }
+  const targetPane =
+    anchor?.pane ??
+    Array.from(document.querySelectorAll<HTMLElement>(".graphPane")).find(
+      (pane) => pane.offsetParent !== null
+    );
+  const scroller = targetPane === undefined ? null : getGraphScroller(targetPane);
+  let nextPan = graphPan;
+  if (targetPane !== undefined && scroller !== null) {
+    const rect = scroller.getBoundingClientRect();
+    const offsetX = anchor === undefined ? rect.width / 2 : anchor.clientX - rect.left;
+    const offsetY = anchor === undefined ? rect.height / 2 : anchor.clientY - rect.top;
+    const contentX = (offsetX - graphPan.x) / previousZoom;
+    const contentY = (offsetY - graphPan.y) / previousZoom;
+    nextPan = {
+      x: offsetX - contentX * nextNormalizedZoom,
+      y: offsetY - contentY * nextNormalizedZoom
+    };
   }
 
   graphZoom = nextNormalizedZoom;
-  applyGraphZoomToAll();
-  for (const [pane, zoomAnchor] of anchors.entries()) {
-    const scroller = getGraphScroller(pane);
-    if (scroller === null) {
-      continue;
-    }
-    scroller.scrollLeft = Math.max(0, zoomAnchor.x * graphZoom - zoomAnchor.offsetX);
-    scroller.scrollTop = Math.max(0, zoomAnchor.y * graphZoom - zoomAnchor.offsetY);
-    saveGraphScroll(pane);
+  if (targetPane !== undefined) {
+    graphPan = clampGraphPanForPane(targetPane, nextPan);
   }
+  applyGraphZoomToAll();
   saveGraphZoom();
   renderDependencyGraphOverlays();
 }
@@ -961,6 +1004,155 @@ function zoomGraphFromWheel(pane: HTMLElement, event: WheelEvent) {
     clientX: event.clientX,
     clientY: event.clientY
   });
+}
+
+function isGraphInteractiveTarget(target: EventTarget | null) {
+  return (
+    target instanceof Element &&
+    target.closest("button,a,input,select,textarea,[role='button']") !== null
+  );
+}
+
+function getGraphPointerPosition(pane: HTMLElement, event: PointerEvent) {
+  const scroller = getGraphScroller(pane);
+  if (scroller === null) {
+    return null;
+  }
+
+  const rect = scroller.getBoundingClientRect();
+  return {
+    x: event.clientX - rect.left,
+    y: event.clientY - rect.top
+  };
+}
+
+function updateGraphSelectionBox() {
+  if (graphSelection === null) {
+    return;
+  }
+
+  const selectionBox = getGraphSelectionBox(graphSelection.pane);
+  if (selectionBox === null) {
+    return;
+  }
+
+  const left = Math.min(graphSelection.startX, graphSelection.currentX);
+  const top = Math.min(graphSelection.startY, graphSelection.currentY);
+  const width = Math.abs(graphSelection.currentX - graphSelection.startX);
+  const height = Math.abs(graphSelection.currentY - graphSelection.startY);
+  selectionBox.hidden = false;
+  selectionBox.style.left = `${left}px`;
+  selectionBox.style.top = `${top}px`;
+  selectionBox.style.width = `${width}px`;
+  selectionBox.style.height = `${height}px`;
+}
+
+function clearGraphSelectionBox(pane: HTMLElement) {
+  const selectionBox = getGraphSelectionBox(pane);
+  if (selectionBox === null) {
+    return;
+  }
+
+  selectionBox.hidden = true;
+  selectionBox.removeAttribute("style");
+}
+
+function zoomGraphToSelection(selection: GraphSelectionState) {
+  const scroller = getGraphScroller(selection.pane);
+  if (scroller === null) {
+    return;
+  }
+
+  const width = Math.abs(selection.currentX - selection.startX);
+  const height = Math.abs(selection.currentY - selection.startY);
+  if (width < GRAPH_SELECTION_MIN_SIZE || height < GRAPH_SELECTION_MIN_SIZE) {
+    return;
+  }
+
+  const viewport = getGraphViewportSize(scroller);
+  const left = Math.min(selection.startX, selection.currentX);
+  const top = Math.min(selection.startY, selection.currentY);
+  const selectedX = (left - graphPan.x) / graphZoom;
+  const selectedY = (top - graphPan.y) / graphZoom;
+  const selectedWidth = width / graphZoom;
+  const selectedHeight = height / graphZoom;
+  const nextZoom = normalizeGraphZoom(
+    Math.min(
+      GRAPH_ZOOM_MAX,
+      (viewport.width - GRAPH_FIT_PADDING * 2) / selectedWidth,
+      (viewport.height - GRAPH_FIT_PADDING * 2) / selectedHeight
+    )
+  );
+
+  graphZoom = nextZoom;
+  graphPan = clampGraphPanForPane(selection.pane, {
+    x: GRAPH_FIT_PADDING - selectedX * graphZoom,
+    y: GRAPH_FIT_PADDING - selectedY * graphZoom
+  });
+  applyGraphZoomToAll();
+  saveGraphZoom();
+  renderDependencyGraphOverlays();
+}
+
+function beginGraphSelection(pane: HTMLElement, event: PointerEvent) {
+  if (event.button !== 0 || isGraphInteractiveTarget(event.target)) {
+    return;
+  }
+
+  const point = getGraphPointerPosition(pane, event);
+  const scroller = getGraphScroller(pane);
+  if (point === null || scroller === null) {
+    return;
+  }
+
+  event.preventDefault();
+  scroller.setPointerCapture(event.pointerId);
+  graphSelection = {
+    pane,
+    pointerId: event.pointerId,
+    startX: point.x,
+    startY: point.y,
+    currentX: point.x,
+    currentY: point.y
+  };
+  updateGraphSelectionBox();
+}
+
+function updateGraphSelection(pane: HTMLElement, event: PointerEvent) {
+  if (graphSelection === null || graphSelection.pane !== pane) {
+    return;
+  }
+
+  const point = getGraphPointerPosition(pane, event);
+  if (point === null) {
+    return;
+  }
+
+  event.preventDefault();
+  graphSelection.currentX = point.x;
+  graphSelection.currentY = point.y;
+  updateGraphSelectionBox();
+}
+
+function finishGraphSelection(pane: HTMLElement, event: PointerEvent) {
+  if (graphSelection === null || graphSelection.pane !== pane) {
+    return;
+  }
+
+  const point = getGraphPointerPosition(pane, event);
+  if (point !== null) {
+    graphSelection.currentX = point.x;
+    graphSelection.currentY = point.y;
+  }
+  const selection = graphSelection;
+  graphSelection = null;
+  event.preventDefault();
+  const scroller = getGraphScroller(pane);
+  if (scroller?.hasPointerCapture(selection.pointerId)) {
+    scroller.releasePointerCapture(selection.pointerId);
+  }
+  clearGraphSelectionBox(pane);
+  zoomGraphToSelection(selection);
 }
 
 function renderDependencyGraphOverlays() {
@@ -1109,6 +1301,18 @@ for (const pane of Array.from(document.querySelectorAll<HTMLElement>(".graphPane
   });
   scroller?.addEventListener("wheel", (event) => zoomGraphFromWheel(pane, event), {
     passive: false
+  });
+  scroller?.addEventListener("pointerdown", (event) => beginGraphSelection(pane, event));
+  scroller?.addEventListener("pointermove", (event) => updateGraphSelection(pane, event));
+  scroller?.addEventListener("pointerup", (event) => finishGraphSelection(pane, event));
+  scroller?.addEventListener("pointercancel", (event) => finishGraphSelection(pane, event));
+  scroller?.addEventListener("dblclick", (event) => {
+    if (isGraphInteractiveTarget(event.target)) {
+      return;
+    }
+    event.preventDefault();
+    fitGraphToViewport();
+    renderDependencyGraphOverlays();
   });
 }
 queryElement<HTMLButtonElement>("#refresh").addEventListener("click", () => {

--- a/web/beadsMain.ts
+++ b/web/beadsMain.ts
@@ -1,4 +1,9 @@
 import type { BeadsRequestMessage } from "../src/beadsProtocol";
+import {
+  computePackedGraphLayout,
+  computeVisibleGraphState,
+  graphEdgeKey
+} from "./beadsGraphModel";
 import { isCollapsedByEpic, shouldShowBeadRow } from "./beadsRowVisibility";
 
 declare function acquireVsCodeApi(): {
@@ -14,6 +19,7 @@ type BeadRow = HTMLTableRowElement & { dataset: DOMStringMap };
 type BeadSection = HTMLElement & { dataset: DOMStringMap };
 type GraphScrollState = { left: number; top: number };
 type GraphPanState = { x: number; y: number };
+type GraphTransformState = { zoom: number; pan: GraphPanState };
 type GraphZoomAnchor = { pane: HTMLElement; clientX: number; clientY: number };
 type GraphSelectionState = {
   pane: HTMLElement;
@@ -23,10 +29,18 @@ type GraphSelectionState = {
   currentX: number;
   currentY: number;
 };
+type GraphPanGestureState = {
+  pane: HTMLElement;
+  pointerId: number;
+  startClientX: number;
+  startClientY: number;
+  startPan: GraphPanState;
+};
 type BeadsWebviewState = {
   viewMode?: ViewMode;
   graphZoom?: number;
   graphPan?: GraphPanState;
+  graphTransforms?: Record<string, GraphTransformState>;
   graphScroll?: Record<string, GraphScrollState>;
   [key: string]: unknown;
 };
@@ -78,6 +92,13 @@ const GRAPH_ZOOM_MIN = 0.05;
 const GRAPH_ZOOM_MAX = 1.8;
 const GRAPH_FIT_PADDING = 16;
 const GRAPH_SELECTION_MIN_SIZE = 12;
+const GRAPH_NODE_WIDTH = 252;
+const GRAPH_LEVEL_GAP = 56;
+const GRAPH_LEVEL_COLUMN_GAP = 24;
+const GRAPH_LANE_GAP = 30;
+const GRAPH_PADDING_X = 28;
+const GRAPH_PADDING_Y = 44;
+const GRAPH_KEYBOARD_PAN_STEP = 40;
 const PRESET_FILTERS: Record<string, StatusFilter[]> = {
   default: ["open", "in_progress", "blocked"],
   open: ["open"],
@@ -94,9 +115,9 @@ let contextMenuRow: BeadRow | null = null;
 let contextMenuWorkspacePath = "";
 let sortState: { key: SortKey; desc: boolean } = { key: "order", desc: false };
 let activeViewMode: ViewMode = normalizeViewMode(vscode.getState()?.viewMode);
-let graphZoom = normalizeGraphZoom(vscode.getState()?.graphZoom);
-let graphPan = normalizeGraphPan(vscode.getState()?.graphPan);
+let graphTransforms = normalizeGraphTransforms(vscode.getState());
 let graphSelection: GraphSelectionState | null = null;
+let graphPanGesture: GraphPanGestureState | null = null;
 let rowClickTimer: number | null = null;
 const collapsedIds = new Set<string>();
 const collapsedEpicIds = new Set<string>();
@@ -147,6 +168,29 @@ function normalizeGraphPan(value: unknown): GraphPanState {
     x: typeof candidate.x === "number" && Number.isFinite(candidate.x) ? candidate.x : 0,
     y: typeof candidate.y === "number" && Number.isFinite(candidate.y) ? candidate.y : 0
   };
+}
+
+function normalizeGraphTransforms(state: BeadsWebviewState | undefined) {
+  const normalized: Record<string, GraphTransformState> = {};
+  const candidates = state?.graphTransforms;
+  if (typeof candidates === "object" && candidates !== null) {
+    for (const [workspacePath, value] of Object.entries(candidates)) {
+      if (typeof value !== "object" || value === null) {
+        continue;
+      }
+      normalized[workspacePath] = {
+        zoom: normalizeGraphZoom((value as { zoom?: unknown }).zoom),
+        pan: normalizeGraphPan((value as { pan?: unknown }).pan)
+      };
+    }
+  }
+  if (Object.keys(normalized).length === 0) {
+    normalized.__legacy__ = {
+      zoom: normalizeGraphZoom(state?.graphZoom),
+      pan: normalizeGraphPan(state?.graphPan)
+    };
+  }
+  return normalized;
 }
 
 function saveWebviewState(patch: Partial<BeadsWebviewState>) {
@@ -209,8 +253,30 @@ function findSectionRows(button: HTMLElement) {
   return section === null ? [] : getVisibleBeadRows(section);
 }
 
+function openGraphBeadDetails(button: HTMLButtonElement) {
+  const issueId = button.dataset.graphDetailsId || "";
+  const workspacePath = button.dataset.graphDetailsWorkspace || "";
+  const section = Array.from(document.querySelectorAll<BeadSection>("section")).find(
+    (candidate) => candidate.dataset.workspacePath === workspacePath
+  );
+  const row = Array.from(section?.querySelectorAll<BeadRow>("tbody .beadRow") ?? []).find(
+    (candidate) => candidate.dataset.id === issueId
+  );
+  if (row === undefined) {
+    return;
+  }
+  applyViewMode("table");
+  if (selectedRow !== row || expandedDetailsRow === null) {
+    toggleRowDetails(row);
+  }
+  row.scrollIntoView({ block: "nearest" });
+  row.querySelector<HTMLButtonElement>(".beadDetailsButton")?.focus();
+}
+
 function closeContextMenu() {
   rowContextMenu.classList.remove("open");
+  rowContextMenu.style.removeProperty("left");
+  rowContextMenu.style.removeProperty("top");
   contextMenuRow = null;
   contextMenuWorkspacePath = "";
 }
@@ -233,15 +299,36 @@ function postAssignStartBead(button: HTMLButtonElement) {
   });
 }
 
-function openContextMenu(row: BeadRow | null, workspacePath: string, event: MouseEvent) {
+function openContextMenu(
+  row: BeadRow | null,
+  workspacePath: string,
+  clientX: number,
+  clientY: number,
+  focusMenu: boolean = false
+) {
   contextMenuRow = row;
   contextMenuWorkspacePath = workspacePath;
   const item = row ? decodeRowItem(row) : null;
   createBeadAction.disabled = !bdAvailable || contextMenuWorkspacePath === "";
   closeBeadAction.disabled = item === null || (row?.dataset.status ?? "") === "closed";
-  rowContextMenu.style.left = `${event.clientX}px`;
-  rowContextMenu.style.top = `${event.clientY}px`;
   rowContextMenu.classList.add("open");
+  const menuRect = rowContextMenu.getBoundingClientRect();
+  const viewportMargin = 4;
+  const left = Math.max(
+    viewportMargin,
+    Math.min(clientX, window.innerWidth - menuRect.width - viewportMargin)
+  );
+  const top = Math.max(
+    viewportMargin,
+    Math.min(clientY, window.innerHeight - menuRect.height - viewportMargin)
+  );
+  rowContextMenu.style.left = `${left}px`;
+  rowContextMenu.style.top = `${top}px`;
+  if (focusMenu) {
+    const firstEnabledAction =
+      rowContextMenu.querySelector<HTMLButtonElement>("button:not(:disabled)");
+    firstEnabledAction?.focus();
+  }
 }
 
 function setsEqual(values: Set<StatusFilter>, expected: StatusFilter[]) {
@@ -435,7 +522,16 @@ function removeExpandedDetails() {
   expandedDetailsRow = null;
 }
 
+function setRowDetailsExpanded(row: BeadRow, expanded: boolean) {
+  row
+    .querySelector<HTMLButtonElement>(".beadDetailsButton")
+    ?.setAttribute("aria-expanded", expanded ? "true" : "false");
+}
+
 function clearSelectedRow() {
+  if (selectedRow !== null) {
+    setRowDetailsExpanded(selectedRow, false);
+  }
   selectedRow?.classList.remove("selected");
   selectedRow = null;
   removeExpandedDetails();
@@ -445,6 +541,7 @@ function expandDetailsRow(row: BeadRow, item: BeadRowItem) {
   removeExpandedDetails();
   const detailsRow = document.createElement("tr");
   detailsRow.className = "inlineDetailsRow";
+  detailsRow.id = row.dataset.detailsId || "";
   const detailsCell = document.createElement("td");
   detailsCell.colSpan = 6;
   detailsCell.innerHTML = renderDetailsMarkup(item);
@@ -452,6 +549,28 @@ function expandDetailsRow(row: BeadRow, item: BeadRowItem) {
   row.insertAdjacentElement("afterend", detailsRow);
   bindCommitLinks(detailsRow);
   expandedDetailsRow = detailsRow;
+}
+
+function toggleRowDetails(row: BeadRow) {
+  if (selectedRow === row) {
+    clearSelectedRow();
+    return;
+  }
+
+  if (selectedRow !== null) {
+    selectedRow.classList.remove("selected");
+    setRowDetailsExpanded(selectedRow, false);
+  }
+  removeExpandedDetails();
+  selectedRow = row;
+  row.classList.add("selected");
+  setRowDetailsExpanded(row, true);
+
+  const item = decodeRowItem(row);
+  if (item !== null) {
+    expandDetailsRow(row, item);
+  }
+  renderHierarchyOverlays();
 }
 
 function getVisibleBeadRows(scope: ParentNode = document) {
@@ -533,6 +652,7 @@ function refreshRowVisibility() {
   refreshGraphNodeVisibility();
   renderHierarchyOverlays();
   if (activeViewMode === "graph") {
+    refreshGraphPresentation();
     fitGraphToViewport();
   }
   renderDependencyGraphOverlays();
@@ -551,6 +671,7 @@ function applyViewMode(mode: ViewMode) {
   tableViewButton.setAttribute("aria-pressed", mode === "table" ? "true" : "false");
   graphViewButton.setAttribute("aria-pressed", mode === "graph" ? "true" : "false");
   if (mode === "graph") {
+    refreshGraphPresentation();
     fitGraphToViewport();
   }
   renderHierarchyOverlays();
@@ -794,6 +915,181 @@ function refreshGraphNodeVisibility() {
   }
 }
 
+function getVisibleGraphNodes(pane: HTMLElement) {
+  return Array.from(pane.querySelectorAll<HTMLElement>(".graphNode[data-graph-id]")).filter(
+    (node) => node.style.display !== "none"
+  );
+}
+
+function updateGraphIssueDrawer(
+  pane: HTMLElement,
+  drawerSelector: string,
+  itemSelector: string,
+  visibleIds: ReadonlySet<string>,
+  summarySelector: string,
+  suffix: string
+) {
+  const drawer = pane.querySelector<HTMLDetailsElement>(drawerSelector);
+  if (drawer === null) {
+    return 0;
+  }
+  let visibleCount = 0;
+  for (const item of Array.from(drawer.querySelectorAll<HTMLElement>(itemSelector))) {
+    const id = item.dataset.warningId ?? item.dataset.riskId ?? "";
+    const visible = visibleIds.has(id);
+    item.hidden = !visible;
+    if (visible) {
+      visibleCount += 1;
+    }
+  }
+  drawer.hidden = visibleCount === 0;
+  const count = drawer.querySelector<HTMLElement>("summary strong");
+  if (count !== null) {
+    count.textContent = String(visibleCount);
+  }
+  const summary = pane.querySelector<HTMLElement>(summarySelector);
+  if (summary !== null) {
+    summary.hidden = visibleCount === 0;
+    summary.textContent = `${visibleCount} ${suffix}`;
+  }
+  return visibleCount;
+}
+
+function refreshGraphDerivedState(pane: HTMLElement) {
+  const visibleNodes = getVisibleGraphNodes(pane);
+  const visibleIds = new Set(visibleNodes.map((node) => node.dataset.graphId || ""));
+  const candidateEdges = Array.from(pane.querySelectorAll<HTMLElement>(".graphEdge")).map(
+    (edge) => ({
+      fromId: edge.dataset.fromId || "",
+      toId: edge.dataset.toId || ""
+    })
+  );
+  const graphState = computeVisibleGraphState(visibleIds, candidateEdges);
+  const criticalIds = new Set(graphState.criticalPathIds);
+
+  for (const node of visibleNodes) {
+    const graphId = node.dataset.graphId || "";
+    const critical = criticalIds.has(graphId);
+    node.dataset.graphLevel = String(graphState.levelsById.get(graphId) ?? 0);
+    node.dataset.critical = critical ? "1" : "0";
+    node.classList.toggle("criticalGraphNode", critical);
+    const badge = node.querySelector<HTMLElement>(".criticalBadge");
+    if (badge !== null) {
+      badge.hidden = !critical;
+    }
+    for (const relation of Array.from(
+      node.querySelectorAll<HTMLElement>(".graphRelation[data-related-ids]")
+    )) {
+      const relatedIds = decodeEncodedJson<string[]>(relation.dataset.relatedIds) ?? [];
+      const visibleRelatedIds = relatedIds.filter((id) => visibleIds.has(id));
+      relation.hidden = visibleRelatedIds.length === 0;
+      const value = relation.querySelector<HTMLElement>(".graphRelationValue");
+      if (value !== null) {
+        value.textContent = visibleRelatedIds.join(", ");
+      }
+    }
+  }
+  for (const edge of Array.from(pane.querySelectorAll<HTMLElement>(".graphEdge"))) {
+    edge.dataset.critical = graphState.criticalEdgeKeys.has(
+      graphEdgeKey(edge.dataset.fromId || "", edge.dataset.toId || "")
+    )
+      ? "1"
+      : "0";
+  }
+
+  const dependencySummary = pane.querySelector<HTMLElement>(".dependencySummary");
+  if (dependencySummary !== null) {
+    dependencySummary.textContent = `${graphState.edges.length} deps`;
+  }
+  const criticalSummary = pane.querySelector<HTMLElement>(".criticalSummary");
+  const pathLabel = graphState.criticalPathIds.join(" -> ");
+  if (criticalSummary !== null) {
+    criticalSummary.hidden = graphState.criticalPathIds.length === 0;
+    criticalSummary.textContent = `${graphState.criticalPathIds.length} critical`;
+    criticalSummary.title = pathLabel;
+  }
+  const pathStrip = pane.querySelector<HTMLElement>(".graphPathStrip");
+  const pathValue = pane.querySelector<HTMLElement>(".graphPathValue");
+  if (pathStrip !== null && pathValue !== null) {
+    const empty = graphState.criticalPathIds.length === 0;
+    pathStrip.classList.toggle("emptyCriticalPath", empty);
+    pathValue.textContent = empty ? "No dependency path yet" : pathLabel;
+    pathValue.title = pathLabel;
+  }
+
+  const warningCount = updateGraphIssueDrawer(
+    pane,
+    ".dependencyIssueDrawer",
+    "[data-warning-id]",
+    visibleIds,
+    ".dependencyWarningSummary",
+    "warnings"
+  );
+  const riskCount = updateGraphIssueDrawer(
+    pane,
+    ".mergeRiskIssueDrawer",
+    "[data-risk-id]",
+    visibleIds,
+    ".mergeRiskSummary",
+    "risk"
+  );
+  const issueStack = pane.querySelector<HTMLElement>(".graphIssueStack");
+  if (issueStack !== null) {
+    issueStack.hidden = warningCount + riskCount === 0;
+  }
+}
+
+function layoutGraphPane(pane: HTMLElement) {
+  const canvas = getGraphCanvas(pane);
+  const content = getGraphContent(pane);
+  if (canvas === null || content === null || pane.offsetParent === null) {
+    return;
+  }
+  const visibleNodes = getVisibleGraphNodes(pane);
+  const layout = computePackedGraphLayout(
+    visibleNodes.map((node) => ({
+      id: node.dataset.graphId || "",
+      level: parseInt(node.dataset.graphLevel || "0", 10),
+      height: node.offsetHeight
+    })),
+    {
+      nodeWidth: GRAPH_NODE_WIDTH,
+      levelGap: GRAPH_LEVEL_GAP,
+      columnGap: GRAPH_LEVEL_COLUMN_GAP,
+      laneGap: GRAPH_LANE_GAP,
+      paddingX: GRAPH_PADDING_X,
+      paddingY: GRAPH_PADDING_Y
+    }
+  );
+  const positions = new Map(layout.nodes.map((node) => [node.id, node]));
+  for (const node of visibleNodes) {
+    const position = positions.get(node.dataset.graphId || "");
+    if (position !== undefined) {
+      node.style.setProperty("--graph-x", `${position.x}px`);
+      node.style.setProperty("--graph-y", `${position.y}px`);
+    }
+  }
+  const levelCenters = new Map(layout.levels.map((level) => [level.level, level.centerX]));
+  for (const guide of Array.from(pane.querySelectorAll<HTMLElement>(".graphLevelGuide"))) {
+    const center = levelCenters.get(parseInt(guide.dataset.graphLevel || "0", 10));
+    guide.hidden = center === undefined;
+    if (center !== undefined) {
+      guide.style.setProperty("--graph-guide-x", `${center}px`);
+    }
+  }
+  canvas.dataset.graphWidth = String(layout.width);
+  canvas.dataset.graphHeight = String(layout.height);
+  content.style.width = `${layout.width}px`;
+  content.style.height = `${layout.height}px`;
+}
+
+function refreshGraphPresentation() {
+  for (const pane of Array.from(document.querySelectorAll<HTMLElement>(".graphPane"))) {
+    refreshGraphDerivedState(pane);
+    layoutGraphPane(pane);
+  }
+}
+
 function getGraphScroller(pane: HTMLElement) {
   return pane.querySelector<HTMLElement>(".graphScroller");
 }
@@ -812,6 +1108,20 @@ function getGraphSelectionBox(pane: HTMLElement) {
 
 function getGraphWorkspaceKey(pane: HTMLElement) {
   return pane.dataset.workspacePath || "default";
+}
+
+function getGraphTransform(pane: HTMLElement): GraphTransformState {
+  return (
+    graphTransforms[getGraphWorkspaceKey(pane)] ??
+    graphTransforms.__legacy__ ?? { zoom: 1, pan: { x: 0, y: 0 } }
+  );
+}
+
+function setGraphTransform(pane: HTMLElement, transform: GraphTransformState) {
+  graphTransforms = {
+    ...graphTransforms,
+    [getGraphWorkspaceKey(pane)]: transform
+  };
 }
 
 function getGraphBaseSize(canvas: HTMLElement) {
@@ -842,11 +1152,13 @@ function getGraphRequiredSize(pane: HTMLElement, base: { width: number; height: 
   return { width, height };
 }
 
-function saveGraphZoom() {
-  saveWebviewState({ graphZoom, graphPan });
+function saveGraphTransforms() {
+  const workspaceTransforms = { ...graphTransforms };
+  delete workspaceTransforms.__legacy__;
+  saveWebviewState({ graphTransforms: workspaceTransforms });
 }
 
-function clampGraphPanForPane(pane: HTMLElement, pan: GraphPanState) {
+function clampGraphPanForPane(pane: HTMLElement, pan: GraphPanState, zoom: number) {
   const scroller = getGraphScroller(pane);
   const canvas = getGraphCanvas(pane);
   if (scroller === null || canvas === null) {
@@ -855,8 +1167,8 @@ function clampGraphPanForPane(pane: HTMLElement, pan: GraphPanState) {
 
   const viewport = getGraphViewportSize(scroller);
   const requiredSize = getGraphRequiredSize(pane, getGraphBaseSize(canvas));
-  const scaledWidth = requiredSize.width * graphZoom;
-  const scaledHeight = requiredSize.height * graphZoom;
+  const scaledWidth = requiredSize.width * zoom;
+  const scaledHeight = requiredSize.height * zoom;
   const minX = Math.min(0, viewport.width - scaledWidth);
   const minY = Math.min(0, viewport.height - scaledHeight);
   const maxX = scaledWidth <= viewport.width ? (viewport.width - scaledWidth) / 2 : 0;
@@ -892,13 +1204,18 @@ function applyGraphZoomToPane(pane: HTMLElement) {
 
   const base = getGraphRequiredSize(pane, getGraphBaseSize(canvas));
   const viewport = getGraphViewportSize(scroller);
+  const transform = getGraphTransform(pane);
   content.style.width = `${base.width}px`;
   content.style.height = `${base.height}px`;
   canvas.style.width = `${viewport.width}px`;
   canvas.style.height = `${viewport.height}px`;
-  content.style.setProperty("--graph-zoom", graphZoom.toFixed(2));
-  content.style.setProperty("--graph-pan-x", `${graphPan.x.toFixed(1)}px`);
-  content.style.setProperty("--graph-pan-y", `${graphPan.y.toFixed(1)}px`);
+  content.style.setProperty("--graph-zoom", transform.zoom.toFixed(2));
+  content.style.setProperty("--graph-pan-x", `${transform.pan.x.toFixed(1)}px`);
+  content.style.setProperty("--graph-pan-y", `${transform.pan.y.toFixed(1)}px`);
+  const zoomValue = pane.querySelector<HTMLElement>(".graphZoomValue");
+  if (zoomValue !== null) {
+    zoomValue.textContent = `${Math.round(transform.zoom * 100)}%`;
+  }
 }
 
 function applyGraphZoomToAll() {
@@ -930,76 +1247,79 @@ function getGraphFitZoomForPane(pane: HTMLElement) {
   return normalizeGraphZoom(fitZoom);
 }
 
-function fitGraphToViewport() {
-  let nextZoom = 1;
-  for (const pane of Array.from(document.querySelectorAll<HTMLElement>(".graphPane"))) {
-    if (pane.offsetParent === null) {
-      continue;
-    }
-    nextZoom = Math.min(nextZoom, getGraphFitZoomForPane(pane));
-  }
-
-  graphZoom = nextZoom;
-  graphPan = { x: 0, y: 0 };
-  for (const pane of Array.from(document.querySelectorAll<HTMLElement>(".graphPane"))) {
-    if (pane.offsetParent === null) {
-      continue;
-    }
-    graphPan = clampGraphPanForPane(pane, graphPan);
-    break;
-  }
-  applyGraphZoomToAll();
-  for (const pane of Array.from(document.querySelectorAll<HTMLElement>(".graphPane"))) {
-    const scroller = getGraphScroller(pane);
-    if (scroller === null) {
-      continue;
-    }
+function fitGraphToPane(pane: HTMLElement, persist: boolean = true) {
+  const nextZoom = getGraphFitZoomForPane(pane);
+  const nextPan = clampGraphPanForPane(pane, { x: 0, y: 0 }, nextZoom);
+  setGraphTransform(pane, { zoom: nextZoom, pan: nextPan });
+  applyGraphZoomToPane(pane);
+  const scroller = getGraphScroller(pane);
+  if (scroller !== null) {
     scroller.scrollLeft = 0;
     scroller.scrollTop = 0;
     saveGraphScroll(pane);
   }
-  saveGraphZoom();
+  if (persist) {
+    saveGraphTransforms();
+  }
 }
 
-function setGraphZoom(nextZoom: number, anchor?: GraphZoomAnchor) {
-  const previousZoom = graphZoom;
+function fitGraphToViewport() {
+  for (const pane of Array.from(document.querySelectorAll<HTMLElement>(".graphPane"))) {
+    if (pane.offsetParent !== null) {
+      fitGraphToPane(pane, false);
+    }
+  }
+  saveGraphTransforms();
+}
+
+function setGraphZoom(pane: HTMLElement, nextZoom: number, anchor?: GraphZoomAnchor) {
+  const currentTransform = getGraphTransform(pane);
+  const previousZoom = currentTransform.zoom;
   const nextNormalizedZoom = normalizeGraphZoom(nextZoom);
   if (Math.abs(previousZoom - nextNormalizedZoom) < 0.001) {
-    return;
+    return false;
   }
 
-  const targetPane =
-    anchor?.pane ??
-    Array.from(document.querySelectorAll<HTMLElement>(".graphPane")).find(
-      (pane) => pane.offsetParent !== null
-    );
-  const scroller = targetPane === undefined ? null : getGraphScroller(targetPane);
-  let nextPan = graphPan;
-  if (targetPane !== undefined && scroller !== null) {
+  const scroller = getGraphScroller(pane);
+  let nextPan = currentTransform.pan;
+  if (scroller !== null) {
     const rect = scroller.getBoundingClientRect();
     const offsetX = anchor === undefined ? rect.width / 2 : anchor.clientX - rect.left;
     const offsetY = anchor === undefined ? rect.height / 2 : anchor.clientY - rect.top;
-    const contentX = (offsetX - graphPan.x) / previousZoom;
-    const contentY = (offsetY - graphPan.y) / previousZoom;
+    const contentX = (offsetX - currentTransform.pan.x) / previousZoom;
+    const contentY = (offsetY - currentTransform.pan.y) / previousZoom;
     nextPan = {
       x: offsetX - contentX * nextNormalizedZoom,
       y: offsetY - contentY * nextNormalizedZoom
     };
   }
 
-  graphZoom = nextNormalizedZoom;
-  if (targetPane !== undefined) {
-    graphPan = clampGraphPanForPane(targetPane, nextPan);
-  }
-  applyGraphZoomToAll();
-  saveGraphZoom();
+  setGraphTransform(pane, {
+    zoom: nextNormalizedZoom,
+    pan: clampGraphPanForPane(pane, nextPan, nextNormalizedZoom)
+  });
+  applyGraphZoomToPane(pane);
+  saveGraphTransforms();
   renderDependencyGraphOverlays();
+  return true;
 }
 
 function zoomGraphFromWheel(pane: HTMLElement, event: WheelEvent) {
-  event.preventDefault();
+  const scroller = getGraphScroller(pane);
+  if (
+    scroller === null ||
+    (document.activeElement !== scroller && !event.ctrlKey && !event.metaKey)
+  ) {
+    return;
+  }
+  const transform = getGraphTransform(pane);
   const zoomFactor = Math.exp(-event.deltaY * 0.002);
-  setGraphZoom(graphZoom * zoomFactor, {
+  const nextZoom = normalizeGraphZoom(transform.zoom * zoomFactor);
+  if (Math.abs(transform.zoom - nextZoom) < 0.001) {
+    return;
+  }
+  event.preventDefault();
+  setGraphZoom(pane, nextZoom, {
     pane,
     clientX: event.clientX,
     clientY: event.clientY
@@ -1070,12 +1390,13 @@ function zoomGraphToSelection(selection: GraphSelectionState) {
   }
 
   const viewport = getGraphViewportSize(scroller);
+  const transform = getGraphTransform(selection.pane);
   const left = Math.min(selection.startX, selection.currentX);
   const top = Math.min(selection.startY, selection.currentY);
-  const selectedX = (left - graphPan.x) / graphZoom;
-  const selectedY = (top - graphPan.y) / graphZoom;
-  const selectedWidth = width / graphZoom;
-  const selectedHeight = height / graphZoom;
+  const selectedX = (left - transform.pan.x) / transform.zoom;
+  const selectedY = (top - transform.pan.y) / transform.zoom;
+  const selectedWidth = width / transform.zoom;
+  const selectedHeight = height / transform.zoom;
   const nextZoom = normalizeGraphZoom(
     Math.min(
       GRAPH_ZOOM_MAX,
@@ -1084,13 +1405,17 @@ function zoomGraphToSelection(selection: GraphSelectionState) {
     )
   );
 
-  graphZoom = nextZoom;
-  graphPan = clampGraphPanForPane(selection.pane, {
-    x: GRAPH_FIT_PADDING - selectedX * graphZoom,
-    y: GRAPH_FIT_PADDING - selectedY * graphZoom
-  });
-  applyGraphZoomToAll();
-  saveGraphZoom();
+  const nextPan = clampGraphPanForPane(
+    selection.pane,
+    {
+      x: GRAPH_FIT_PADDING - selectedX * nextZoom,
+      y: GRAPH_FIT_PADDING - selectedY * nextZoom
+    },
+    nextZoom
+  );
+  setGraphTransform(selection.pane, { zoom: nextZoom, pan: nextPan });
+  applyGraphZoomToPane(selection.pane);
+  saveGraphTransforms();
   renderDependencyGraphOverlays();
 }
 
@@ -1106,6 +1431,7 @@ function beginGraphSelection(pane: HTMLElement, event: PointerEvent) {
   }
 
   event.preventDefault();
+  scroller.focus({ preventScroll: true });
   scroller.setPointerCapture(event.pointerId);
   graphSelection = {
     pane,
@@ -1155,6 +1481,122 @@ function finishGraphSelection(pane: HTMLElement, event: PointerEvent) {
   zoomGraphToSelection(selection);
 }
 
+function beginGraphPan(pane: HTMLElement, event: PointerEvent) {
+  if (
+    isGraphInteractiveTarget(event.target) ||
+    (event.button !== 1 && !(event.button === 0 && event.shiftKey))
+  ) {
+    return false;
+  }
+  const scroller = getGraphScroller(pane);
+  if (scroller === null) {
+    return false;
+  }
+  event.preventDefault();
+  scroller.focus({ preventScroll: true });
+  scroller.setPointerCapture(event.pointerId);
+  scroller.classList.add("isPanning");
+  graphPanGesture = {
+    pane,
+    pointerId: event.pointerId,
+    startClientX: event.clientX,
+    startClientY: event.clientY,
+    startPan: getGraphTransform(pane).pan
+  };
+  return true;
+}
+
+function updateGraphPan(pane: HTMLElement, event: PointerEvent) {
+  if (graphPanGesture === null || graphPanGesture.pane !== pane) {
+    return false;
+  }
+  event.preventDefault();
+  const transform = getGraphTransform(pane);
+  const nextPan = clampGraphPanForPane(
+    pane,
+    {
+      x: graphPanGesture.startPan.x + event.clientX - graphPanGesture.startClientX,
+      y: graphPanGesture.startPan.y + event.clientY - graphPanGesture.startClientY
+    },
+    transform.zoom
+  );
+  setGraphTransform(pane, { ...transform, pan: nextPan });
+  applyGraphZoomToPane(pane);
+  return true;
+}
+
+function finishGraphPan(pane: HTMLElement, event: PointerEvent) {
+  if (graphPanGesture === null || graphPanGesture.pane !== pane) {
+    return false;
+  }
+  event.preventDefault();
+  const gesture = graphPanGesture;
+  graphPanGesture = null;
+  const scroller = getGraphScroller(pane);
+  scroller?.classList.remove("isPanning");
+  if (scroller?.hasPointerCapture(gesture.pointerId)) {
+    scroller.releasePointerCapture(gesture.pointerId);
+  }
+  saveGraphTransforms();
+  return true;
+}
+
+function handleGraphPointerDown(pane: HTMLElement, event: PointerEvent) {
+  if (!beginGraphPan(pane, event)) {
+    beginGraphSelection(pane, event);
+  }
+}
+
+function handleGraphPointerMove(pane: HTMLElement, event: PointerEvent) {
+  if (!updateGraphPan(pane, event)) {
+    updateGraphSelection(pane, event);
+  }
+}
+
+function handleGraphPointerEnd(pane: HTMLElement, event: PointerEvent) {
+  if (!finishGraphPan(pane, event)) {
+    finishGraphSelection(pane, event);
+  }
+}
+
+function panGraphByKeyboard(pane: HTMLElement, deltaX: number, deltaY: number) {
+  const transform = getGraphTransform(pane);
+  const pan = clampGraphPanForPane(
+    pane,
+    { x: transform.pan.x + deltaX, y: transform.pan.y + deltaY },
+    transform.zoom
+  );
+  setGraphTransform(pane, { ...transform, pan });
+  applyGraphZoomToPane(pane);
+  saveGraphTransforms();
+}
+
+function handleGraphKeydown(pane: HTMLElement, event: KeyboardEvent) {
+  if (event.key === "+" || event.key === "=") {
+    event.preventDefault();
+    setGraphZoom(pane, getGraphTransform(pane).zoom * 1.2);
+  } else if (event.key === "-") {
+    event.preventDefault();
+    setGraphZoom(pane, getGraphTransform(pane).zoom / 1.2);
+  } else if (event.key === "0") {
+    event.preventDefault();
+    fitGraphToPane(pane);
+    renderDependencyGraphOverlays();
+  } else if (event.key === "ArrowLeft") {
+    event.preventDefault();
+    panGraphByKeyboard(pane, GRAPH_KEYBOARD_PAN_STEP, 0);
+  } else if (event.key === "ArrowRight") {
+    event.preventDefault();
+    panGraphByKeyboard(pane, -GRAPH_KEYBOARD_PAN_STEP, 0);
+  } else if (event.key === "ArrowUp") {
+    event.preventDefault();
+    panGraphByKeyboard(pane, 0, GRAPH_KEYBOARD_PAN_STEP);
+  } else if (event.key === "ArrowDown") {
+    event.preventDefault();
+    panGraphByKeyboard(pane, 0, -GRAPH_KEYBOARD_PAN_STEP);
+  }
+}
+
 function renderDependencyGraphOverlays() {
   for (const [paneIndex, pane] of Array.from(
     document.querySelectorAll<HTMLElement>(".graphPane")
@@ -1171,6 +1613,7 @@ function renderDependencyGraphOverlays() {
     }
 
     const contentRect = content.getBoundingClientRect();
+    const transform = getGraphTransform(pane);
     const width = Math.max(1, Math.round(content.offsetWidth));
     const height = Math.max(1, Math.round(content.offsetHeight));
     overlay.setAttribute("viewBox", `0 0 ${width} ${height}`);
@@ -1195,10 +1638,10 @@ function renderDependencyGraphOverlays() {
 
       const fromRect = fromNode.getBoundingClientRect();
       const toRect = toNode.getBoundingClientRect();
-      const x1 = (fromRect.right - contentRect.left) / graphZoom;
-      const y1 = (fromRect.top - contentRect.top + fromRect.height / 2) / graphZoom;
-      const x2 = (toRect.left - contentRect.left) / graphZoom;
-      const y2 = (toRect.top - contentRect.top + toRect.height / 2) / graphZoom;
+      const x1 = (fromRect.right - contentRect.left) / transform.zoom;
+      const y1 = (fromRect.top - contentRect.top + fromRect.height / 2) / transform.zoom;
+      const x2 = (toRect.left - contentRect.left) / transform.zoom;
+      const y2 = (toRect.top - contentRect.top + toRect.height / 2) / transform.zoom;
       const gap = Math.max(18, Math.abs(x2 - x1) * 0.34);
       const d =
         x2 >= x1
@@ -1232,6 +1675,12 @@ document.addEventListener("click", (event) => {
   if (!(target instanceof Element)) {
     return;
   }
+  const graphDetailsButton = target.closest(".graphDetailsBead") as HTMLButtonElement | null;
+  if (graphDetailsButton !== null) {
+    event.preventDefault();
+    openGraphBeadDetails(graphDetailsButton);
+    return;
+  }
   const assignStartButton = target.closest(".assignStartBead") as HTMLButtonElement | null;
   if (assignStartButton !== null) {
     event.preventDefault();
@@ -1242,6 +1691,12 @@ document.addEventListener("click", (event) => {
     filterMenu.classList.remove("open");
   }
   if (!target.closest(".contextMenu")) {
+    closeContextMenu();
+  }
+});
+document.addEventListener("keydown", (event) => {
+  if (event.key === "Escape") {
+    filterMenu.classList.remove("open");
     closeContextMenu();
   }
 });
@@ -1260,7 +1715,12 @@ document.addEventListener("contextmenu", (event) => {
   }
 
   event.preventDefault();
-  openContextMenu(row, row?.dataset.workspacePath || section?.dataset.workspacePath || "", event);
+  openContextMenu(
+    row,
+    row?.dataset.workspacePath || section?.dataset.workspacePath || "",
+    event.clientX,
+    event.clientY
+  );
 });
 createBeadAction.addEventListener("click", () => {
   const workspacePath = contextMenuWorkspacePath;
@@ -1287,6 +1747,7 @@ closeBeadAction.addEventListener("click", () => {
 });
 window.addEventListener("resize", () => {
   if (activeViewMode === "graph") {
+    refreshGraphPresentation();
     fitGraphToViewport();
   } else {
     applyGraphZoomToAll();
@@ -1302,18 +1763,34 @@ for (const pane of Array.from(document.querySelectorAll<HTMLElement>(".graphPane
   scroller?.addEventListener("wheel", (event) => zoomGraphFromWheel(pane, event), {
     passive: false
   });
-  scroller?.addEventListener("pointerdown", (event) => beginGraphSelection(pane, event));
-  scroller?.addEventListener("pointermove", (event) => updateGraphSelection(pane, event));
-  scroller?.addEventListener("pointerup", (event) => finishGraphSelection(pane, event));
-  scroller?.addEventListener("pointercancel", (event) => finishGraphSelection(pane, event));
+  scroller?.addEventListener("pointerdown", (event) => handleGraphPointerDown(pane, event));
+  scroller?.addEventListener("pointermove", (event) => handleGraphPointerMove(pane, event));
+  scroller?.addEventListener("pointerup", (event) => handleGraphPointerEnd(pane, event));
+  scroller?.addEventListener("pointercancel", (event) => handleGraphPointerEnd(pane, event));
+  scroller?.addEventListener("keydown", (event) => handleGraphKeydown(pane, event));
   scroller?.addEventListener("dblclick", (event) => {
     if (isGraphInteractiveTarget(event.target)) {
       return;
     }
     event.preventDefault();
-    fitGraphToViewport();
+    fitGraphToPane(pane);
     renderDependencyGraphOverlays();
   });
+  for (const button of Array.from(
+    pane.querySelectorAll<HTMLButtonElement>("button[data-graph-action]")
+  )) {
+    button.addEventListener("click", () => {
+      const action = button.dataset.graphAction;
+      if (action === "in") {
+        setGraphZoom(pane, getGraphTransform(pane).zoom * 1.2);
+      } else if (action === "out") {
+        setGraphZoom(pane, getGraphTransform(pane).zoom / 1.2);
+      } else if (action === "fit") {
+        fitGraphToPane(pane);
+        renderDependencyGraphOverlays();
+      }
+    });
+  }
 }
 queryElement<HTMLButtonElement>("#refresh").addEventListener("click", () => {
   vscode.postMessage({ command: "refresh" });
@@ -1404,32 +1881,16 @@ for (const button of Array.from(document.querySelectorAll<HTMLButtonElement>(".s
 }
 for (const row of Array.from(document.querySelectorAll<BeadRow>("tbody tr.beadRow"))) {
   const toggleButton = row.querySelector<HTMLButtonElement>(".collapseToggle");
-  const selectRow = (event: MouseEvent) => {
-    const target = event.target;
-    if (target instanceof Element && target.closest("button")) {
-      return;
-    }
-
-    if (selectedRow === row) {
-      clearSelectedRow();
-      return;
-    }
-
-    selectedRow?.classList.remove("selected");
-    removeExpandedDetails();
-    selectedRow = row;
-    row.classList.add("selected");
-
-    const item = decodeRowItem(row);
-    if (item !== null) {
-      expandDetailsRow(row, item);
-    }
-    renderHierarchyOverlays();
-  };
+  const detailsButton = row.querySelector<HTMLButtonElement>(".beadDetailsButton");
 
   toggleButton?.addEventListener("click", (event) => {
     event.stopPropagation();
     toggleRowCollapse(row);
+  });
+  detailsButton?.addEventListener("click", (event) => {
+    event.stopPropagation();
+    clearRowClickTimer();
+    toggleRowDetails(row);
   });
   row.addEventListener("click", (event) => {
     if (event.target instanceof Element && event.target.closest("button")) {
@@ -1439,7 +1900,7 @@ for (const row of Array.from(document.querySelectorAll<BeadRow>("tbody tr.beadRo
     const clickDelayMs = isCollapsibleRow(row) ? 260 : 160;
     rowClickTimer = window.setTimeout(() => {
       rowClickTimer = null;
-      selectRow(event);
+      toggleRowDetails(row);
     }, clickDelayMs);
   });
   row.addEventListener("dblclick", (event) => {
@@ -1460,7 +1921,21 @@ for (const row of Array.from(document.querySelectorAll<BeadRow>("tbody tr.beadRo
       }
       return;
     }
-    selectRow(event);
+    toggleRowDetails(row);
+  });
+  row.addEventListener("keydown", (event) => {
+    if (event.key !== "F10" || !event.shiftKey) {
+      return;
+    }
+    event.preventDefault();
+    const rect = row.getBoundingClientRect();
+    openContextMenu(
+      row,
+      row.dataset.workspacePath || "",
+      rect.left + Math.min(24, rect.width / 2),
+      rect.top + Math.min(24, rect.height / 2),
+      true
+    );
   });
 }
 


### PR DESCRIPTION
## Summary

- Add rectangle-select zoom to the Beads Graph view.

## Changes

- Add a graph selection rectangle overlay.
- Store graph pan with graph zoom and render the graph with translate plus scale.
- Zoom into a dragged rectangle and reset to fit on double click.
- Keep wheel and trackpad zoom centered around the pointer using pan state.

## Testing

- ./node_modules/.bin/oxfmt .
- git diff --check
- ./node_modules/.bin/oxlint
- ./node_modules/.bin/tsc -p ./src --noEmit
- ./node_modules/.bin/tsc -p ./web --noEmit
- ./node_modules/.bin/vitest run
- node_modules/.pnpm/esbuild@0.28.1/node_modules/esbuild/bin/esbuild --bundle web/beadsMain.ts --outfile=/tmp/beads-webview-rectangle-zoom.js --minify --target=es6 --format=iife

## Notes

- bd sync is unavailable in this local bd CLI; used bd dolt push instead.