### PR TITLE
chore(release): prepare v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-07-30
+
 ### Added
 
 - Add a locally validated Plan Draft preview with dependency graph, Critical Path, parallel groups,
@@ -440,7 +442,8 @@
 
 Initial release
 
-[Unreleased]: https://github.com/ToppyMicroServices/beads-git-graph/compare/v0.4.20260710...HEAD
+[Unreleased]: https://github.com/ToppyMicroServices/beads-git-graph/compare/v0.6.0...HEAD
+[0.6.0]: https://github.com/ToppyMicroServices/beads-git-graph/compare/v0.4.20260710...v0.6.0
 [0.4.20260710]: https://github.com/ToppyMicroServices/beads-git-graph/compare/v0.4.20260709...v0.4.20260710
 [0.4.20260709]: https://github.com/ToppyMicroServices/beads-git-graph/compare/v0.4.20260708...v0.4.20260709
 [0.4.20260708]: https://github.com/ToppyMicroServices/beads-git-graph/compare/v0.4.20260706...v0.4.20260708

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Beads Git Graph
 
 [![MIT License](https://img.shields.io/badge/license-MIT-2ea44f?style=flat-square)](./LICENSE)
-[![Version 0.4.20260710](https://img.shields.io/badge/version-0.4.20260710-0366d6?style=flat-square)](./CHANGELOG.md)
+[![Version 0.6.0](https://img.shields.io/badge/version-0.6.0-0366d6?style=flat-square)](./CHANGELOG.md)
 
 A local-first project manager for coordinating dependency-linked work across different AI providers
 and requested models, with Git graph and Beads issue tools in one VS Code extension.

--- a/docs/user-testing-agent-project-manager.md
+++ b/docs/user-testing-agent-project-manager.md
@@ -277,21 +277,21 @@ browser page. It verifies user-visible source behavior, but it does not exercise
 
 ## Packaged VSIX result — 2026-07-24; rebuilt and Host-smoked 2026-07-30
 
-- **Artifact:** `beads-git-graph-0.4.20260710.vsix`, SHA-256
-  `29fe0f386e444e565871ff56e1a470fa553e9bfb4f30cca9e76fb629e63dcdfb`.
+- **Artifact:** `beads-git-graph-0.6.0.vsix`, SHA-256
+  `86b8aa0713883c12ca81053b0df8a85cd799cd3a786756fbe55801cdc523a3da`.
 - **Package inspection:** the current artifact contains provider/model selection, Host-side
   readiness/schema/dependency checks, response-artifact preservation, bounded parallel requests,
   pointer-centered Graph zoom, normal-drag pan, dependency and parent-child line rendering, static
   Sync warning styling, keyed incremental refresh handling, view-specific Details hosts, visible
   parallel-target filtering, relevant capability gating, client/Host duplicate-action guards,
-  fetch-on-Graph-refresh, last-fetch metadata, and explicit local remote-tracking labels. VSCE
-  rewrote the README screenshot to the repository asset URL.
+  fetch-on-Graph-refresh, last-fetch metadata, explicit local remote-tracking labels, and sanitized
+  incremental webview updates. VSCE rewrote the README screenshot to the repository asset URL.
 - **Install/activation boundary:** a package built immediately before the final Host safety changes
-  installed as `ToppyMicroServices.beads-git-graph@0.4.20260710` in an isolated extension directory
+  installed as `ToppyMicroServices.beads-git-graph@0.6.0` in an isolated extension directory
   and opened the Beads webview in an isolated VS Code profile. The final artifact above was rebuilt
   and installed into new isolated extension/profile directories; the latest
   `code --list-extensions --show-versions` check confirmed
-  `toppymicroservices.beads-git-graph@0.4.20260710`. The final artifact then passed an isolated VS
+  `toppymicroservices.beads-git-graph@0.6.0`. The final artifact then passed an isolated VS
   Code 1.127.0 Extension Host smoke: activation, the View/Refresh/Clear Artifacts commands, the
   machine-scoped `bdPath`, the default-enabled Graph fetch setting, and the packaged Restricted Mode
   manifest were asserted before the Host exited with code 0. Restricted Mode interaction and the

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "beads-git-graph",
   "displayName": "Beads Git Graph",
-  "version": "0.4.20260710",
+  "version": "0.6.0",
   "description": "Git graph and Beads issue tools for VS Code.",
   "categories": [
     "Other",


### PR DESCRIPTION
## Summary

- Prepare the first stable Marketplace release since `0.4.20260710`.
- Promote the multi-provider agent project manager, Graph stability, fetch visibility, and security changes merged in #238.

## Changes

- Bump the extension version to `0.6.0`, above the current `0.5.20260730` daily prerelease line.
- Move the accumulated unreleased notes into the `0.6.0` changelog section.
- Update the README badge and packaged VSIX verification record.

## Testing

- `pnpm run format`
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm test` (53 files, 345 tests)
- `pnpm audit --audit-level high`
- `pnpm run package`
- Installed `beads-git-graph-0.6.0.vsix` in an isolated VS Code profile
- Packaged Extension Host smoke passed

## Notes

- Candidate VSIX SHA-256: `86b8aa0713883c12ca81053b0df8a85cd799cd3a786756fbe55801cdc523a3da`.
- Marketplace publication will be triggered by the GitHub Release after this PR merges.
- The repository Beads database was not migrated, initialized, bootstrapped, synchronized, or written.
