### PR TITLE
fix(beads): tolerate unsupported CLI options

### DIFF
--- a/src/beadsSync.ts
+++ b/src/beadsSync.ts
@@ -11,7 +11,16 @@ export type BeadsSyncCapability =
   | { supported: false; reason: string };
 
 function isUnknownSyncCommand(error: unknown) {
-  return error instanceof Error && /unknown command "sync"/i.test(error.message);
+  return error instanceof Error && /unknown command ["']?sync["']?/i.test(error.message);
+}
+
+function isUnsupportedFlushOption(error: unknown) {
+  return (
+    error instanceof Error &&
+    /(?:unknown (?:flag|option)|unrecognized option|no such option|flag provided but not defined)[^\n]*-+flush-only/i.test(
+      error.message
+    )
+  );
 }
 
 export async function probeBeadsSyncCapability(
@@ -41,7 +50,7 @@ export async function flushBeadsWorkspace(
     await runBdCommand(["sync", "--flush-only"], workspacePath);
     return { status: "flushed" };
   } catch (error) {
-    if (!isUnknownSyncCommand(error)) {
+    if (!isUnknownSyncCommand(error) && !isUnsupportedFlushOption(error)) {
       throw error;
     }
     return { status: "unsupported" };

--- a/src/beadsWriteCapability.ts
+++ b/src/beadsWriteCapability.ts
@@ -87,7 +87,11 @@ function classifyFailedProbe(
         migrationGateReason ?? (observed || "The Beads schema is incompatible with the active CLI.")
     };
   }
-  if (/unknown command|command not found|no such command|unknown flag/i.test(observed)) {
+  if (
+    /unknown command|command not found|no such command|unknown (?:flag|option)|unrecognized option|no such option|flag provided but not defined/i.test(
+      observed
+    )
+  ) {
     return {
       supported: false,
       state: "unsupported-command",

--- a/tests/beadsSync.test.ts
+++ b/tests/beadsSync.test.ts
@@ -117,4 +117,29 @@ describe("flushBeadsWorkspace", () => {
       status: "flushed"
     });
   });
+
+  it.each([
+    "unknown flag: --flush-only",
+    "unknown option '--flush-only'",
+    "unrecognized option '--flush-only'",
+    "flag provided but not defined: -flush-only"
+  ])("reports an unsupported flush option for: %s", async (message) => {
+    const runBdCommand = vi.fn(async () => {
+      throw new Error(message);
+    });
+
+    await expect(flushBeadsWorkspace(runBdCommand, "/tmp/demo")).resolves.toEqual({
+      status: "unsupported"
+    });
+  });
+
+  it("does not hide unrelated sync failures", async () => {
+    const runBdCommand = vi.fn(async () => {
+      throw new Error("database connection failed");
+    });
+
+    await expect(flushBeadsWorkspace(runBdCommand, "/tmp/demo")).rejects.toThrow(
+      "database connection failed"
+    );
+  });
 });

--- a/tests/beadsWriteCapability.test.ts
+++ b/tests/beadsWriteCapability.test.ts
@@ -68,6 +68,21 @@ describe("Beads plan write capability", () => {
     expect(capability.reason).toContain("unknown command");
   });
 
+  it.each([
+    "unknown option '--metadata'",
+    "unrecognized option '--metadata'",
+    "no such option: --metadata",
+    "flag provided but not defined: -metadata"
+  ])("classifies an unsupported CLI option for: %s", async (message) => {
+    const capability = await probeBeadsWriteCapability(true, null, async () =>
+      result(1, "", message)
+    );
+
+    expect(capability.supported).toBe(false);
+    expect(capability.state).toBe("unsupported-command");
+    expect(capability.reason).toContain("metadata");
+  });
+
   it("disables import on a structured remote schema migration gate", async () => {
     const capability = await probeBeadsWriteCapability(true, null, async () =>
       result(


### PR DESCRIPTION
## Summary

- Handle Beads CLI option differences without surfacing expected compatibility failures as runtime errors.

## Changes

- Treat unsupported `sync --flush-only` flags as an unavailable optional flush step.
- Recognize common `unknown option` and `unrecognized option` diagnostics during write capability probes.
- Preserve unrelated database and command failures as real errors.
- Add regression coverage for multiple CLI diagnostic formats.

## Testing

- `npm test` (53 files, 354 tests)
- `npm run lint`
- `npm run compile`
- `git diff --check`

## Notes

- The local Beads CLI is v1.1.0. It supports the read options used by Graph/Table but does not provide `bd sync`.
- The local Beads database remains on schema v49 with the v53 remote migration gate. No migration, bootstrap, or Beads write was performed.