### PR TITLE
fix(beads): add Start and End graph flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Beads Git Graph
 
 [![MIT License](https://img.shields.io/badge/license-MIT-2ea44f?style=flat-square)](./LICENSE)
-[![Version 0.6.0](https://img.shields.io/badge/version-0.6.0-0366d6?style=flat-square)](./CHANGELOG.md)
+[![Version 0.6.1](https://img.shields.io/badge/version-0.6.1-0366d6?style=flat-square)](./CHANGELOG.md)
 
 A local-first project manager for coordinating dependency-linked work across different AI providers
 and requested models, with Git graph and Beads issue tools in one VS Code extension.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "beads-git-graph",
   "displayName": "Beads Git Graph",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Git graph and Beads issue tools for VS Code.",
   "categories": [
     "Other",

--- a/src/beadsWebview.ts
+++ b/src/beadsWebview.ts
@@ -31,6 +31,9 @@ const GRAPH_LEVEL_COLUMN_GAP = 24;
 const GRAPH_LANE_GAP = 30;
 const GRAPH_PADDING_X = 28;
 const GRAPH_PADDING_Y = 44;
+const GRAPH_BOUNDARY_NODE_HEIGHT_ESTIMATE = 62;
+const GRAPH_START_ID = "__beads_flow_start__";
+const GRAPH_END_ID = "__beads_flow_end__";
 
 function getRawAssigneeLabel(item: BeadItem) {
   return item.assignee.trim() !== "" && item.assignee !== "-" ? item.assignee.trim() : "";
@@ -344,7 +347,8 @@ function renderAgentWorkQueue(
   workspacePath: string,
   agentAliases: ReadonlyMap<string, string>,
   writeAvailable: boolean,
-  writeUnavailableReason: string
+  writeUnavailableReason: string,
+  diagnosticHtml: string
 ) {
   const queue = buildAgentWorkQueue(items);
   const overview = AGENT_WORK_LANES.map(
@@ -366,7 +370,7 @@ function renderAgentWorkQueue(
     return `<div class="agentWorkLane" data-work-lane="${lane}"><div class="agentWorkLaneHeader"><span>${AGENT_WORK_LANE_LABELS[lane]}</span><span class="agentWorkLaneCount">${queue.counts[lane]}</span></div><div class="agentWorkLaneCards">${cards}<div class="agentWorkLaneEmpty"${queue.counts[lane] === 0 ? "" : " hidden"}>No matching work</div></div></div>`;
   }).join("");
 
-  return `<div class="agentWorkQueue" data-workspace-path="${escapeHtml(workspacePath)}"><div class="agentWorkQueueHeader"><div><div class="agentWorkQueueTitle">Agent Work Queue</div><div class="agentWorkQueueHint">Derived from Beads status and recorded Git/PR metadata. “Recorded in progress” is not live-agent monitoring.</div></div><div class="agentWorkOverview">${overview}</div></div><div class="agentWorkDetailsHost"></div><div class="agentWorkLanes">${lanes}</div></div>`;
+  return `<div class="agentWorkQueue" data-workspace-path="${escapeHtml(workspacePath)}">${diagnosticHtml}<div class="agentWorkQueueHeader"><div><div class="agentWorkQueueTitle">Agent Work Queue</div><div class="agentWorkQueueHint">Derived from Beads status and recorded Git/PR metadata. “Recorded in progress” is not live-agent monitoring.</div></div><div class="agentWorkOverview">${overview}</div></div><div class="agentWorkDetailsHost"></div><div class="agentWorkLanes">${lanes}</div></div>`;
 }
 
 function renderBeadsDependencyGraph(
@@ -397,12 +401,22 @@ function renderBeadsDependencyGraph(
     nodesByLevel.set(node.level, nodes);
   }
 
-  const edgeHtml = graph.edges
+  const dependencyEdgeHtml = graph.edges
     .map(
       (edge) =>
         `<span class="graphEdge" data-from-id="${escapeHtml(edge.fromId)}" data-to-id="${escapeHtml(edge.toId)}" data-critical="${edge.critical ? "1" : "0"}"></span>`
     )
     .join("");
+  const boundaryEdgeHtml = graph.nodes
+    .flatMap((node) => {
+      const id = node.item.id;
+      return [
+        `<span class="graphEdge" data-graph-boundary="start" data-from-id="${GRAPH_START_ID}" data-to-id="${escapeHtml(id)}" data-critical="0"${blockersById.has(id) ? " hidden" : ""}></span>`,
+        `<span class="graphEdge" data-graph-boundary="end" data-from-id="${escapeHtml(id)}" data-to-id="${GRAPH_END_ID}" data-critical="0"${blocksById.has(id) ? " hidden" : ""}></span>`
+      ];
+    })
+    .join("");
+  const edgeHtml = dependencyEdgeHtml + boundaryEdgeHtml;
   const levelCount = maxLevel + 1;
   const levelLayouts = Array.from({ length: levelCount }, (_, level) => {
     const nodes = nodesByLevel.get(level) ?? [];
@@ -413,25 +427,29 @@ function renderBeadsDependencyGraph(
 
     return { nodes, rowCount, columnCount, width, x: 0 };
   });
-  let nextLevelX = GRAPH_PADDING_X;
+  const startLevelX = GRAPH_PADDING_X;
+  let nextLevelX = startLevelX + GRAPH_NODE_WIDTH + GRAPH_LEVEL_GAP;
   for (const layout of levelLayouts) {
     layout.x = nextLevelX;
     nextLevelX += layout.width + GRAPH_LEVEL_GAP;
   }
+  const endLevelX = nextLevelX;
   const graphRowCount = Math.max(1, ...levelLayouts.map((layout) => layout.rowCount));
-  const graphWidth = nextLevelX - GRAPH_LEVEL_GAP + GRAPH_PADDING_X;
-  const graphHeight =
-    GRAPH_PADDING_Y * 2 +
-    graphRowCount * GRAPH_NODE_HEIGHT_ESTIMATE +
-    Math.max(0, graphRowCount - 1) * GRAPH_LANE_GAP;
-  const levelGuideHtml = Array.from({ length: levelCount }, (_, level) => {
+  const graphBodyHeight =
+    graphRowCount * GRAPH_NODE_HEIGHT_ESTIMATE + Math.max(0, graphRowCount - 1) * GRAPH_LANE_GAP;
+  const graphWidth = endLevelX + GRAPH_NODE_WIDTH + GRAPH_PADDING_X;
+  const graphHeight = GRAPH_PADDING_Y * 2 + graphBodyHeight;
+  const boundaryNodeY =
+    GRAPH_PADDING_Y + Math.max(0, (graphBodyHeight - GRAPH_BOUNDARY_NODE_HEIGHT_ESTIMATE) / 2);
+  const taskLevelGuideHtml = Array.from({ length: levelCount }, (_, level) => {
     const layout = levelLayouts[level];
     const x = layout.x + layout.width / 2;
     const label = level === 0 ? "Ready" : `L${level + 1}`;
     const detail = level === 0 ? "No blockers" : "After deps";
 
-    return `<span class="graphLevelGuide" data-graph-level="${level}" style="--graph-guide-x:${x}px"><span class="graphLevelLabel"><strong>${label}</strong><small>${detail}</small></span></span>`;
+    return `<span class="graphLevelGuide" data-graph-level="${level + 1}" data-graph-task-level="${level}" style="--graph-guide-x:${x}px"><span class="graphLevelLabel"><strong>${label}</strong><small>${detail}</small></span></span>`;
   }).join("");
+  const levelGuideHtml = `<span class="graphLevelGuide graphBoundaryGuide" data-graph-level="0" data-graph-boundary="start" style="--graph-guide-x:${startLevelX + GRAPH_NODE_WIDTH / 2}px"><span class="graphLevelLabel"><strong>Start</strong><small>Flow begins</small></span></span>${taskLevelGuideHtml}<span class="graphLevelGuide graphBoundaryGuide" data-graph-level="${maxLevel + 2}" data-graph-boundary="end" style="--graph-guide-x:${endLevelX + GRAPH_NODE_WIDTH / 2}px"><span class="graphLevelLabel"><strong>End</strong><small>Flow complete</small></span></span>`;
   const nodeHtml = Array.from({ length: levelCount }, (_, level) => {
     const layout = levelLayouts[level];
     const rowOffset =
@@ -536,10 +554,11 @@ function renderBeadsDependencyGraph(
         ]
           .filter((badge) => badge !== "")
           .join("");
-        return `<div class="graphNode ${node.critical ? "criticalGraphNode" : ""}${dependencyWarning === "" ? "" : " dependencyWarningGraphNode"}${mergeRiskWarning === "" ? "" : " mergeRiskGraphNode"}" data-graph-id="${escapeHtml(item.id)}" data-graph-level="${level}" data-graph-lane="${lane}" data-status="${escapeHtml(normalizedStatus)}" data-critical="${node.critical ? "1" : "0"}" data-parent-id="${escapeHtml(parentId)}" data-epic-id="${escapeHtml(epicId ?? "")}" data-depth="${depth}" style="${initialDisplay}--graph-x:${x}px;--graph-y:${y}px"><div class="graphNodeTop"><span class="typeBadge type-${escapeHtml(normalizedType)}">${escapeHtml(item.type)}</span><span class="criticalBadge"${node.critical ? "" : " hidden"}>Critical path</span></div><div class="beadId">${escapeHtml(item.id)}</div><div class="graphNodeTitle">${escapeHtml(item.title)}</div><div class="graphNodeBadges"><span class="statusBadge status-${escapeHtml(normalizedStatus.replace(/_/g, "-"))}">${escapeHtml(beadStatusLabel(normalizedStatus))}</span><span class="priorityBadge priority-${escapeHtml(normalizedPriority.toLowerCase())}">${escapeHtml(normalizedPriority)}</span>${graphBadges}</div>${dependencyWarning === "" ? "" : `<div class="graphWarning">${escapeHtml(dependencyWarning)}</div>`}${mergeRiskWarning === "" ? "" : `<div class="graphWarning graphMergeRisk">${escapeHtml(mergeRiskWarning)}</div>`}${dependencyLines === "" ? "" : `<div class="graphRelations">${dependencyLines}</div>`}<div class="graphNodeActions"><button class="graphDetailsBead" type="button" data-graph-details-id="${escapeHtml(item.id)}" data-graph-details-workspace="${escapeHtml(workspacePath)}" aria-label="${escapeHtml(`Details for ${taskActionContext}`)}">Details</button>${actionHtml}</div></div>`;
+        return `<div class="graphNode graphLayoutNode ${node.critical ? "criticalGraphNode" : ""}${dependencyWarning === "" ? "" : " dependencyWarningGraphNode"}${mergeRiskWarning === "" ? "" : " mergeRiskGraphNode"}" data-graph-id="${escapeHtml(item.id)}" data-graph-level="${level + 1}" data-graph-lane="${lane}" data-status="${escapeHtml(normalizedStatus)}" data-critical="${node.critical ? "1" : "0"}" data-parent-id="${escapeHtml(parentId)}" data-epic-id="${escapeHtml(epicId ?? "")}" data-depth="${depth}" style="${initialDisplay}--graph-x:${x}px;--graph-y:${y}px"><div class="graphNodeTop"><span class="typeBadge type-${escapeHtml(normalizedType)}">${escapeHtml(item.type)}</span><span class="criticalBadge"${node.critical ? "" : " hidden"}>Critical path</span></div><div class="beadId">${escapeHtml(item.id)}</div><div class="graphNodeTitle">${escapeHtml(item.title)}</div><div class="graphNodeBadges"><span class="statusBadge status-${escapeHtml(normalizedStatus.replace(/_/g, "-"))}">${escapeHtml(beadStatusLabel(normalizedStatus))}</span><span class="priorityBadge priority-${escapeHtml(normalizedPriority.toLowerCase())}">${escapeHtml(normalizedPriority)}</span>${graphBadges}</div>${dependencyWarning === "" ? "" : `<div class="graphWarning">${escapeHtml(dependencyWarning)}</div>`}${mergeRiskWarning === "" ? "" : `<div class="graphWarning graphMergeRisk">${escapeHtml(mergeRiskWarning)}</div>`}${dependencyLines === "" ? "" : `<div class="graphRelations">${dependencyLines}</div>`}<div class="graphNodeActions"><button class="graphDetailsBead" type="button" data-graph-details-id="${escapeHtml(item.id)}" data-graph-details-workspace="${escapeHtml(workspacePath)}" aria-label="${escapeHtml(`Details for ${taskActionContext}`)}">Details</button>${actionHtml}</div></div>`;
       })
       .join("");
   }).join("");
+  const boundaryNodeHtml = `<div class="graphBoundaryNode graphLayoutNode" data-graph-id="${GRAPH_START_ID}" data-graph-boundary="start" data-graph-level="0" style="--graph-x:${startLevelX}px;--graph-y:${boundaryNodeY}px"><span class="graphBoundaryIcon" aria-hidden="true">▶</span><strong>Start</strong><small>Ready work begins</small></div><div class="graphBoundaryNode graphLayoutNode" data-graph-id="${GRAPH_END_ID}" data-graph-boundary="end" data-graph-level="${maxLevel + 2}" style="--graph-x:${endLevelX}px;--graph-y:${boundaryNodeY}px"><span class="graphBoundaryIcon" aria-hidden="true">✓</span><strong>End</strong><small>All paths complete</small></div>`;
   const dependencyWarningSummary =
     dependencyWarnings.size > 0
       ? `<span class="summaryPill dependencyWarningSummary">${dependencyWarnings.size} warnings</span>`
@@ -573,10 +592,10 @@ function renderBeadsDependencyGraph(
   const criticalSummary = `<span class="summaryPill criticalSummary" title="${escapeHtml(graph.criticalPathIds.join(" -> "))}"${graph.criticalPathIds.length > 0 ? "" : " hidden"}>${graph.criticalPathIds.length} critical</span>`;
   const criticalPathHtml = `<div class="graphPathStrip${graph.criticalPathIds.length > 0 ? "" : " emptyCriticalPath"}"><span>Critical Path</span><strong class="graphPathValue" title="${escapeHtml(graph.criticalPathIds.join(" -> "))}">${graph.criticalPathIds.length > 0 ? escapeHtml(graph.criticalPathIds.join(" -> ")) : "No dependency path yet"}</strong></div>`;
   const graphLegendHtml =
-    '<div class="graphLegend"><span class="dependencyLegend">Dependency</span><span class="criticalLegend">Critical path</span><span class="parentLegend">Parent</span><span class="riskLegend">Merge/worktree risk</span></div>';
+    '<div class="graphLegend"><span class="flowLegend">Start / End flow</span><span class="dependencyLegend">Dependency</span><span class="criticalLegend">Critical path</span><span class="parentLegend">Parent</span><span class="riskLegend">Merge/worktree risk</span></div>';
   const graphIssuesHtml = `<div class="graphIssueStack">${dependencyWarningHtml}${mergeRiskHtml}</div>`;
 
-  return `<div class="graphPane" data-workspace-path="${escapeHtml(workspacePath)}"><div class="graphHeader"><div><div class="workspaceName">Execution Map</div><div class="graphGestureHint">Point anywhere and wheel to zoom there · Drag to pan · Option/Alt+drag a box to zoom · Double-click to fit</div></div><div class="graphHeaderActions"><div class="workspaceSummary"><span class="summaryPill dependencySummary">${graph.edges.length} deps</span>${criticalSummary}${dependencyWarningSummary}${mergeRiskSummary}</div><div class="graphControls" role="group" aria-label="Graph zoom controls"><button type="button" data-graph-action="out" title="Zoom out" aria-label="Zoom out">−</button><span class="graphZoomValue" aria-live="polite">100%</span><button type="button" data-graph-action="in" title="Zoom in" aria-label="Zoom in">+</button><button type="button" data-graph-action="fit">Fit</button></div></div></div>${graphIssuesHtml}<div class="graphMapFrame"><div class="graphMapHeader"><div class="graphMapHeaderMain">${criticalPathHtml}${graphLegendHtml}</div></div><div class="graphScroller" tabindex="0" aria-label="Dependency graph. Point anywhere and wheel to zoom around that location. Drag to pan, Option or Alt drag a box to zoom, use arrow keys to pan, and press zero to fit."><div class="graphCanvas" data-graph-width="${graphWidth}" data-graph-height="${graphHeight}" style="width:${graphWidth}px;height:${graphHeight}px"><div class="graphContent" style="width:${graphWidth}px;height:${graphHeight}px;--graph-node-width:${GRAPH_NODE_WIDTH}px">${edgeHtml}<svg class="dependencyOverlay" aria-hidden="true"></svg>${levelGuideHtml}<div class="graphNodes">${nodeHtml}</div></div></div><div class="graphZoomSelection" hidden></div></div></div></div>`;
+  return `<div class="graphPane" data-workspace-path="${escapeHtml(workspacePath)}"><div class="graphHeader"><div><div class="workspaceName">Execution Map</div><div class="graphGestureHint">Point anywhere and wheel to zoom there · Drag to pan · Option/Alt+drag a box to zoom · Double-click to fit</div></div><div class="graphHeaderActions"><div class="workspaceSummary"><span class="summaryPill dependencySummary">${graph.edges.length} deps</span>${criticalSummary}${dependencyWarningSummary}${mergeRiskSummary}</div><div class="graphControls" role="group" aria-label="Graph zoom controls"><button type="button" data-graph-action="out" title="Zoom out" aria-label="Zoom out">−</button><span class="graphZoomValue" aria-live="polite">100%</span><button type="button" data-graph-action="in" title="Zoom in" aria-label="Zoom in">+</button><button type="button" data-graph-action="fit">Fit</button></div></div></div>${graphIssuesHtml}<div class="graphMapFrame"><div class="graphMapHeader"><div class="graphMapHeaderMain">${criticalPathHtml}${graphLegendHtml}</div></div><div class="graphScroller" tabindex="0" aria-label="Dependency graph. Point anywhere and wheel to zoom around that location. Drag to pan, Option or Alt drag a box to zoom, use arrow keys to pan, and press zero to fit."><div class="graphCanvas" data-graph-width="${graphWidth}" data-graph-height="${graphHeight}" style="width:${graphWidth}px;height:${graphHeight}px"><div class="graphContent" style="width:${graphWidth}px;height:${graphHeight}px;--graph-node-width:${GRAPH_NODE_WIDTH}px">${edgeHtml}<svg class="dependencyOverlay" aria-hidden="true"></svg>${levelGuideHtml}<div class="graphNodes">${boundaryNodeHtml}${nodeHtml}</div></div></div><div class="graphZoomSelection" hidden></div></div></div></div>`;
 }
 
 export function renderBeadsWebviewHtml(
@@ -877,14 +896,15 @@ export function renderBeadsWebviewHtml(
           group.workspacePath,
           agentAliases,
           writeAvailable,
-          writeUnavailableReason
+          writeUnavailableReason,
+          writeCapabilityWarning
         );
         const parallelAction =
           parallelStartTargets.length > 1
             ? `<button class="startParallelBeads workspaceAction" type="button" data-start-parallel-workspace="${escapeHtml(group.workspacePath)}" data-start-parallel-items="${encodeJsonData(parallelStartTargets)}" data-start-parallel-skipped="${encodeJsonData(skippedParallelTargets)}" title="${escapeHtml(writeAvailable ? `Assign and start the parallel-ready tasks currently visible through filters${skippedParallelTargets.length > 0 ? `; ${skippedParallelTargets.length} visible active task(s) may be skipped with reasons` : ""}` : writeUnavailableReason)}" aria-label="${escapeHtml(`Start ${parallelStartTargets.length} currently visible parallel-ready tasks in ${workspaceTitle}`)}"${writeAvailable ? "" : " disabled"}>${parallelStartTargets.length} Start Parallel</button>`
             : "";
 
-        return `<section data-workspace-path="${escapeHtml(group.workspacePath)}" data-write-available="${workspaceWriteAvailable ? "1" : "0"}" data-write-unavailable-reason="${escapeHtml(workspaceWriteUnavailableReason)}"><div class="workspaceHeader"><div class="workspaceName">${escapeHtml(workspaceTitle)}</div><div class="workspaceHeaderRight"><div class="workspaceSummary">${workspaceSummary}</div>${parallelAction}</div></div>${writeCapabilityWarning}<div class="tableWrap"><svg class="hierarchyOverlay" aria-hidden="true"></svg><table><thead><tr><th><button class="sortToggle" data-sort-key="type" type="button" title="Sort by type">Type <span class="sortIcon" data-sort-key="type"> </span></button></th><th>Parallel</th><th>Title</th><th>Status</th><th><button class="sortToggle" data-sort-key="priority" type="button" title="Sort by priority">Priority <span class="sortIcon" data-sort-key="priority"> </span></button></th><th><button class="sortToggle" data-sort-key="updated" type="button" title="Sort by updated">Updated <span class="sortIcon" data-sort-key="updated"> </span></button></th></tr></thead><tbody>${itemRows}</tbody></table></div>${graphHtml}${agentWorkQueueHtml}</section>`;
+        return `<section data-workspace-path="${escapeHtml(group.workspacePath)}" data-write-available="${workspaceWriteAvailable ? "1" : "0"}" data-write-unavailable-reason="${escapeHtml(workspaceWriteUnavailableReason)}"><div class="workspaceHeader"><div class="workspaceName">${escapeHtml(workspaceTitle)}</div><div class="workspaceHeaderRight"><div class="workspaceSummary">${workspaceSummary}</div>${parallelAction}</div></div><div class="tableWrap"><svg class="hierarchyOverlay" aria-hidden="true"></svg><table><thead><tr><th><button class="sortToggle" data-sort-key="type" type="button" title="Sort by type">Type <span class="sortIcon" data-sort-key="type"> </span></button></th><th>Parallel</th><th>Title</th><th>Status</th><th><button class="sortToggle" data-sort-key="priority" type="button" title="Sort by priority">Priority <span class="sortIcon" data-sort-key="priority"> </span></button></th><th><button class="sortToggle" data-sort-key="updated" type="button" title="Sort by updated">Updated <span class="sortIcon" data-sort-key="updated"> </span></button></th></tr></thead><tbody>${itemRows}</tbody></table></div>${graphHtml}${agentWorkQueueHtml}</section>`;
       })
       .join("");
     const emptyHtml = result.emptyWorkspaces
@@ -1029,7 +1049,7 @@ body[data-view-mode="graph"] .tableWrap,body[data-view-mode="control"] .tableWra
 body[data-view-mode="table"] .graphPane,body[data-view-mode="control"] .graphPane{display:none;}
 body[data-view-mode="table"] .agentWorkQueue,body[data-view-mode="graph"] .agentWorkQueue{display:none;}
 body[data-view-mode="table"] .agentWriteWarning,body[data-view-mode="graph"] .agentWriteWarning{display:none;}
-body[data-view-mode="table"] #beadsErrors,body[data-view-mode="graph"] #beadsErrors{display:none;}
+#beadsErrors{display:none!important;}
 body[data-view-mode="plan"] #beadsWorkspaceViews{display:none;}
 body:not([data-view-mode="plan"]) #planDraftView{display:none;}
 body:not([data-view-mode="control"]) #parallelBatchResult{display:none;}
@@ -1200,6 +1220,7 @@ th:nth-child(1){width:52px;}th:nth-child(2){width:72px;}th:nth-child(4){width:78
 .graphLegend{display:flex;flex-wrap:wrap;justify-content:flex-end;gap:6px;margin:0;}
 .graphLegend span{display:inline-flex;align-items:center;gap:5px;min-height:18px;padding:1px 7px;border-radius:999px;border:1px solid var(--vscode-panel-border);font-size:10px;font-weight:700;color:var(--vscode-descriptionForeground);background:rgba(128,128,128,.08);}
 .graphLegend span::before{content:"";width:14px;height:0;border-top:2px solid currentColor;}
+.flowLegend{color:var(--vscode-textLink-foreground,#3b82f6)!important;}
 .dependencyLegend{color:rgba(148,163,184,.95)!important;}
 .criticalLegend{color:var(--vscode-charts-pink,#ec4899)!important;}
 .criticalLegend::before{border-top-width:3px!important;}
@@ -1217,9 +1238,11 @@ th:nth-child(1){width:52px;}th:nth-child(2){width:72px;}th:nth-child(4){width:78
 .graphZoomSelection{position:absolute;z-index:6;border:1px solid var(--vscode-focusBorder,#3b82f6);background:rgba(59,130,246,.16);box-shadow:0 0 0 1px rgba(59,130,246,.18) inset;pointer-events:none;}
 .dependencyOverlay{position:absolute;inset:0;z-index:1;width:100%;height:100%;pointer-events:none;overflow:visible;}
 .dependencyPath{fill:none;stroke:rgba(148,163,184,.8);stroke-width:1.4;stroke-linecap:round;stroke-linejoin:round;vector-effect:non-scaling-stroke;}
+.dependencyPath.boundaryDependencyPath{stroke:var(--vscode-textLink-foreground,#3b82f6);stroke-width:1.8;}
 .dependencyPath.criticalDependencyPath{stroke:var(--vscode-charts-pink,#ec4899);stroke-width:2;}
 .graphParentPath{fill:none;stroke:var(--vscode-textLink-foreground,#3b82f6);stroke-width:1.4;stroke-dasharray:6 5;stroke-linecap:round;stroke-linejoin:round;vector-effect:non-scaling-stroke;}
 .dependencyArrowHead{fill:rgba(148,163,184,.88);}
+.boundaryDependencyArrowHead{fill:var(--vscode-textLink-foreground,#3b82f6);}
 .criticalDependencyArrowHead{fill:var(--vscode-charts-pink,#ec4899);}
 .graphLevelGuide{position:absolute;top:0;bottom:18px;left:var(--graph-guide-x);z-index:0;border-left:1px dashed rgba(128,128,128,.28);}
 .graphLevelLabel{position:absolute;top:10px;left:8px;display:grid;gap:1px;min-width:82px;color:var(--vscode-descriptionForeground);letter-spacing:0;}
@@ -1227,6 +1250,10 @@ th:nth-child(1){width:52px;}th:nth-child(2){width:72px;}th:nth-child(4){width:78
 .graphLevelLabel small{font-size:10px;font-weight:650;line-height:1.15;color:var(--vscode-descriptionForeground);}
 .graphNodes{position:absolute;inset:0;z-index:2;}
 .graphNode{box-sizing:border-box;position:absolute;left:var(--graph-x);top:var(--graph-y);width:var(--graph-node-width,280px);border:1px solid var(--vscode-panel-border);border-radius:8px;background:var(--vscode-sideBar-background,var(--vscode-editor-background));padding:8px;box-shadow:0 1px 3px rgba(0,0,0,.12);}
+.graphBoundaryNode{box-sizing:border-box;position:absolute;left:var(--graph-x);top:var(--graph-y);display:grid;grid-template-columns:32px 1fr;grid-template-rows:auto auto;column-gap:9px;align-items:center;width:var(--graph-node-width,280px);min-height:62px;padding:9px 12px;border:1px solid var(--vscode-focusBorder,var(--vscode-textLink-foreground,#3b82f6));border-radius:999px;background:color-mix(in srgb,var(--vscode-textLink-foreground,#3b82f6) 12%,var(--vscode-editor-background));box-shadow:0 2px 8px rgba(0,0,0,.15);}
+.graphBoundaryIcon{grid-row:1 / 3;display:grid;place-items:center;width:30px;height:30px;border-radius:999px;background:var(--vscode-textLink-foreground,#3b82f6);color:var(--vscode-button-foreground,#fff);font-size:13px;font-weight:800;}
+.graphBoundaryNode strong{font-size:13px;line-height:1.2;}
+.graphBoundaryNode small{color:var(--vscode-descriptionForeground);font-size:10px;font-weight:650;line-height:1.2;}
 .graphNode.criticalGraphNode{border-color:rgba(236,72,153,.62);box-shadow:inset 3px 0 0 var(--vscode-charts-pink,#ec4899), 0 1px 3px rgba(0,0,0,.12);}
 .graphNode.dependencyWarningGraphNode{border-color:rgba(245,158,11,.58);box-shadow:inset 3px 0 0 var(--vscode-editorWarning-foreground,#f59e0b), 0 1px 3px rgba(0,0,0,.12);}
 .graphNode.mergeRiskGraphNode{border-color:rgba(239,68,68,.58);box-shadow:inset 3px 0 0 var(--vscode-errorForeground,#ef4444), 0 1px 3px rgba(0,0,0,.12);}
@@ -1399,7 +1426,7 @@ code{font-family:var(--vscode-editor-font-family);}
 <div id="beadsWorkspaceViews">${bodyHtml}</div>
 ${planDraftHtml}
 <div id="beadsWarnings">${warningHtml}</div>
-<div id="beadsErrors">${errorHtml}</div>
+<div id="beadsErrors" hidden>${errorHtml}</div>
 <script nonce="${nonce}" src="${scriptUri}"></script>
 </body>
 </html>`;

--- a/tests/beadsGraphModel.test.ts
+++ b/tests/beadsGraphModel.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  computeGraphBoundaryState,
   computePackedGraphLayout,
   computeVisibleGraphState,
   graphEdgeKey
@@ -33,6 +34,27 @@ describe("visible beads graph state", () => {
 
   it("does not report isolated nodes as a dependency path", () => {
     expect(computeVisibleGraphState(["ready"], []).criticalPathIds).toEqual([]);
+  });
+
+  it("connects roots to Start and leaves to End", () => {
+    const boundary = computeGraphBoundaryState(
+      ["root-a", "root-b", "middle", "leaf"],
+      [
+        { fromId: "root-a", toId: "middle" },
+        { fromId: "root-b", toId: "middle" },
+        { fromId: "middle", toId: "leaf" }
+      ]
+    );
+
+    expect(boundary.startIds).toEqual(new Set(["root-a", "root-b"]));
+    expect(boundary.endIds).toEqual(new Set(["leaf"]));
+  });
+
+  it("connects every isolated task through Start and End", () => {
+    const boundary = computeGraphBoundaryState(["parallel-a", "parallel-b"], []);
+
+    expect(boundary.startIds).toEqual(new Set(["parallel-a", "parallel-b"]));
+    expect(boundary.endIds).toEqual(new Set(["parallel-a", "parallel-b"]));
   });
 });
 

--- a/tests/beadsMissionControlWebview.test.ts
+++ b/tests/beadsMissionControlWebview.test.ts
@@ -158,6 +158,14 @@ describe("Agent Project Manager webview", () => {
     expect(html).toContain('<button id="controlView" type="button">Manage</button>');
     expect(html).toContain("Agent Work Queue");
     expect(html).toContain('<div class="agentWorkDetailsHost"></div>');
+    expect(html).toContain(
+      'data-graph-boundary="start" data-from-id="__beads_flow_start__" data-to-id="queue-1"'
+    );
+    expect(html).toContain(
+      'data-graph-boundary="end" data-from-id="queue-1" data-to-id="__beads_flow_end__"'
+    );
+    expect(html).toContain("Ready work begins");
+    expect(html).toContain("All paths complete");
 
     for (const lane of ["attention", "review", "running", "queue", "done"]) {
       expect(html).toContain(`data-work-lane="${lane}"`);
@@ -372,6 +380,11 @@ describe("Agent Project Manager webview", () => {
 
     expect(html).toContain("<strong>AI actions disabled</strong>");
     expect(html).toContain("Beads schema v49 is incompatible with v53.");
+    const queueStart = html.indexOf('<div class="agentWorkQueue"');
+    const diagnosticStart = html.indexOf('<div class="warnings agentWriteWarning">');
+    expect(queueStart).toBeGreaterThan(-1);
+    expect(diagnosticStart).toBeGreaterThan(queueStart);
+    expect(html).toContain('<div id="beadsErrors" hidden>');
     const startButton = getTagContaining(
       getAgentCard(html, "ready-1"),
       "button",

--- a/tests/beadsWebviewMetadata.test.ts
+++ b/tests/beadsWebviewMetadata.test.ts
@@ -147,9 +147,8 @@ describe("beads webview presentation metadata", () => {
     expect(beadsWebview).toContain(
       'body[data-view-mode="table"] .agentWriteWarning,body[data-view-mode="graph"] .agentWriteWarning{display:none;}'
     );
-    expect(beadsWebview).toContain(
-      'body[data-view-mode="table"] #beadsErrors,body[data-view-mode="graph"] #beadsErrors{display:none;}'
-    );
+    expect(beadsWebview).toContain("#beadsErrors{display:none!important;}");
+    expect(beadsWebview).toContain('<div id="beadsErrors" hidden>');
     expect(beadsMain).toContain("getGraphRequiredSize");
     expect(beadsMain).toContain("getGraphViewportSize");
     expect(beadsWebview).toContain("graphLevelGuide");
@@ -157,6 +156,10 @@ describe("beads webview presentation metadata", () => {
     expect(beadsWebview).toContain("No blockers");
     expect(beadsWebview).toContain("After deps");
     expect(beadsWebview).toContain("graphNodes");
+    expect(beadsWebview).toContain("graphBoundaryNode");
+    expect(beadsWebview).toContain('data-graph-boundary="start"');
+    expect(beadsWebview).toContain('data-graph-boundary="end"');
+    expect(beadsWebview).toContain("Start / End flow");
     expect(beadsWebview).toContain("data-graph-lane");
     expect(beadsWebview).toContain("data-epic-id");
     expect(beadsWebview).toContain("data-depth");
@@ -284,6 +287,7 @@ describe("beads webview presentation metadata", () => {
     expect(beadsMain).toContain("data-graph-action");
     expect(beadsMain).toContain("refreshGraphDerivedState");
     expect(beadsMain).toContain("computeVisibleGraphState");
+    expect(beadsMain).toContain("computeGraphBoundaryState");
     expect(beadsMain).toContain("layoutGraphPane");
     expect(beadsMain).toContain("computePackedGraphLayout");
     expect(beadsMain).toContain("node.offsetHeight");

--- a/web/beadsGraphModel.ts
+++ b/web/beadsGraphModel.ts
@@ -10,6 +10,11 @@ export interface VisibleGraphState {
   criticalEdgeKeys: Set<string>;
 }
 
+export interface GraphBoundaryState {
+  startIds: Set<string>;
+  endIds: Set<string>;
+}
+
 export interface GraphLayoutNode {
   id: string;
   level: number;
@@ -34,6 +39,27 @@ export interface GraphLayoutResult {
 
 export function graphEdgeKey(fromId: string, toId: string) {
   return `${fromId}\0${toId}`;
+}
+
+export function computeGraphBoundaryState(
+  nodeIds: Iterable<string>,
+  edges: Iterable<VisibleGraphEdge>
+): GraphBoundaryState {
+  const visibleIds = new Set(nodeIds);
+  const incomingIds = new Set<string>();
+  const outgoingIds = new Set<string>();
+  for (const edge of edges) {
+    if (!visibleIds.has(edge.fromId) || !visibleIds.has(edge.toId)) {
+      continue;
+    }
+    outgoingIds.add(edge.fromId);
+    incomingIds.add(edge.toId);
+  }
+
+  return {
+    startIds: new Set(Array.from(visibleIds).filter((id) => !incomingIds.has(id))),
+    endIds: new Set(Array.from(visibleIds).filter((id) => !outgoingIds.has(id)))
+  };
 }
 
 export function computeVisibleGraphState(

--- a/web/beadsMain.ts
+++ b/web/beadsMain.ts
@@ -15,6 +15,7 @@ import {
 import type { BeadsWriteCapability } from "../src/beadsWriteCapability";
 import { renderPlanDraftPreview } from "../src/planPreview";
 import {
+  computeGraphBoundaryState,
   computePackedGraphLayout,
   computeVisibleGraphState,
   graphEdgeKey
@@ -867,6 +868,7 @@ const CLIENT_OWNED_STYLE_CLASSES = [
   "graphCanvas",
   "graphContent",
   "graphNode",
+  "graphBoundaryNode",
   "graphLevelGuide"
 ];
 
@@ -2038,6 +2040,12 @@ function getVisibleGraphNodes(pane: HTMLElement) {
   );
 }
 
+function getVisibleGraphLayoutNodes(pane: HTMLElement) {
+  return Array.from(pane.querySelectorAll<HTMLElement>(".graphLayoutNode[data-graph-id]")).filter(
+    (node) => node.style.display !== "none"
+  );
+}
+
 function updateGraphIssueDrawer(
   pane: HTMLElement,
   drawerSelector: string,
@@ -2075,19 +2083,35 @@ function updateGraphIssueDrawer(
 function refreshGraphDerivedState(pane: HTMLElement) {
   const visibleNodes = getVisibleGraphNodes(pane);
   const visibleIds = new Set(visibleNodes.map((node) => node.dataset.graphId || ""));
-  const candidateEdges = Array.from(pane.querySelectorAll<HTMLElement>(".graphEdge")).map(
-    (edge) => ({
-      fromId: edge.dataset.fromId || "",
-      toId: edge.dataset.toId || ""
-    })
-  );
+  const candidateEdges = Array.from(
+    pane.querySelectorAll<HTMLElement>(".graphEdge:not([data-graph-boundary])")
+  ).map((edge) => ({
+    fromId: edge.dataset.fromId || "",
+    toId: edge.dataset.toId || ""
+  }));
   const graphState = computeVisibleGraphState(visibleIds, candidateEdges);
+  const boundaryState = computeGraphBoundaryState(visibleIds, graphState.edges);
   const criticalIds = new Set(graphState.criticalPathIds);
+  const maximumTaskLevel = Math.max(0, ...graphState.levelsById.values());
+  const endLevel = maximumTaskLevel + 2;
+
+  for (const boundaryNode of Array.from(
+    pane.querySelectorAll<HTMLElement>(".graphBoundaryNode[data-graph-boundary]")
+  )) {
+    boundaryNode.style.display = visibleNodes.length > 0 ? "" : "none";
+    boundaryNode.dataset.graphLevel =
+      boundaryNode.dataset.graphBoundary === "start" ? "0" : String(endLevel);
+  }
+  const endGuide = pane.querySelector<HTMLElement>('.graphLevelGuide[data-graph-boundary="end"]');
+  if (endGuide !== null) {
+    endGuide.dataset.graphLevel = String(endLevel);
+    endGuide.hidden = visibleNodes.length === 0;
+  }
 
   for (const node of visibleNodes) {
     const graphId = node.dataset.graphId || "";
     const critical = criticalIds.has(graphId);
-    node.dataset.graphLevel = String(graphState.levelsById.get(graphId) ?? 0);
+    node.dataset.graphLevel = String((graphState.levelsById.get(graphId) ?? 0) + 1);
     node.dataset.critical = critical ? "1" : "0";
     node.classList.toggle("criticalGraphNode", critical);
     const badge = node.querySelector<HTMLElement>(".criticalBadge");
@@ -2107,6 +2131,19 @@ function refreshGraphDerivedState(pane: HTMLElement) {
     }
   }
   for (const edge of Array.from(pane.querySelectorAll<HTMLElement>(".graphEdge"))) {
+    const boundary = edge.dataset.graphBoundary;
+    if (boundary === "start") {
+      edge.hidden = !boundaryState.startIds.has(edge.dataset.toId || "");
+      edge.dataset.critical = "0";
+      continue;
+    }
+    if (boundary === "end") {
+      edge.hidden = !boundaryState.endIds.has(edge.dataset.fromId || "");
+      edge.dataset.critical = "0";
+      continue;
+    }
+    edge.hidden =
+      !visibleIds.has(edge.dataset.fromId || "") || !visibleIds.has(edge.dataset.toId || "");
     edge.dataset.critical = graphState.criticalEdgeKeys.has(
       graphEdgeKey(edge.dataset.fromId || "", edge.dataset.toId || "")
     )
@@ -2163,7 +2200,7 @@ function layoutGraphPane(pane: HTMLElement) {
   if (canvas === null || content === null || pane.offsetParent === null) {
     return;
   }
-  const visibleNodes = getVisibleGraphNodes(pane);
+  const visibleNodes = getVisibleGraphLayoutNodes(pane);
   const layout = computePackedGraphLayout(
     visibleNodes.map((node) => ({
       id: node.dataset.graphId || "",
@@ -2260,7 +2297,7 @@ function getGraphViewportSize(scroller: HTMLElement) {
 function getGraphRequiredSize(pane: HTMLElement, base: { width: number; height: number }) {
   let width = base.width;
   let height = base.height;
-  for (const node of Array.from(pane.querySelectorAll<HTMLElement>(".graphNode"))) {
+  for (const node of Array.from(pane.querySelectorAll<HTMLElement>(".graphLayoutNode"))) {
     if (node.style.display === "none") {
       continue;
     }
@@ -2821,13 +2858,14 @@ function renderDependencyGraphOverlays() {
     overlay.style.height = `${height}px`;
 
     const nodesById = new Map(
-      Array.from(pane.querySelectorAll<HTMLElement>(".graphNode[data-graph-id]"))
+      Array.from(pane.querySelectorAll<HTMLElement>(".graphLayoutNode[data-graph-id]"))
         .filter((node) => node.style.display !== "none")
         .map((node) => [node.dataset.graphId || "", node])
     );
     const markerId = `dependencyArrow-${paneIndex}`;
+    const boundaryMarkerId = `boundaryDependencyArrow-${paneIndex}`;
     const criticalMarkerId = `criticalDependencyArrow-${paneIndex}`;
-    const markerDefs = `<defs><marker id="${markerId}" viewBox="0 0 10 10" refX="8.5" refY="5" markerWidth="6" markerHeight="6" orient="auto"><path class="dependencyArrowHead" d="M0 0 L10 5 L0 10 Z" /></marker><marker id="${criticalMarkerId}" viewBox="0 0 10 10" refX="8.5" refY="5" markerWidth="6.5" markerHeight="6.5" orient="auto"><path class="criticalDependencyArrowHead" d="M0 0 L10 5 L0 10 Z" /></marker></defs>`;
+    const markerDefs = `<defs><marker id="${markerId}" viewBox="0 0 10 10" refX="8.5" refY="5" markerWidth="6" markerHeight="6" orient="auto"><path class="dependencyArrowHead" d="M0 0 L10 5 L0 10 Z" /></marker><marker id="${boundaryMarkerId}" viewBox="0 0 10 10" refX="8.5" refY="5" markerWidth="6" markerHeight="6" orient="auto"><path class="boundaryDependencyArrowHead" d="M0 0 L10 5 L0 10 Z" /></marker><marker id="${criticalMarkerId}" viewBox="0 0 10 10" refX="8.5" refY="5" markerWidth="6.5" markerHeight="6.5" orient="auto"><path class="criticalDependencyArrowHead" d="M0 0 L10 5 L0 10 Z" /></marker></defs>`;
     const getConnectionPath = (fromNode: HTMLElement, toNode: HTMLElement) => {
       const fromRect = fromNode.getBoundingClientRect();
       const toRect = toNode.getBoundingClientRect();
@@ -2851,6 +2889,9 @@ function renderDependencyGraphOverlays() {
     }
     let paths = "";
     for (const edge of Array.from(pane.querySelectorAll<HTMLElement>(".graphEdge"))) {
+      if (edge.hidden) {
+        continue;
+      }
       const fromNode = nodesById.get(edge.dataset.fromId || "");
       const toNode = nodesById.get(edge.dataset.toId || "");
       if (fromNode === undefined || toNode === undefined) {
@@ -2858,9 +2899,15 @@ function renderDependencyGraphOverlays() {
       }
 
       const d = getConnectionPath(fromNode, toNode);
+      const boundaryClass = edge.dataset.graphBoundary ? " boundaryDependencyPath" : "";
       const criticalClass = edge.dataset.critical === "1" ? " criticalDependencyPath" : "";
-      const arrowId = edge.dataset.critical === "1" ? criticalMarkerId : markerId;
-      paths += `<path class="dependencyPath${criticalClass}" marker-end="url(#${arrowId})" d="${d}" />`;
+      const arrowId =
+        edge.dataset.critical === "1"
+          ? criticalMarkerId
+          : edge.dataset.graphBoundary
+            ? boundaryMarkerId
+            : markerId;
+      paths += `<path class="dependencyPath${boundaryClass}${criticalClass}" marker-end="url(#${arrowId})" d="${d}" />`;
     }
     overlay.innerHTML = markerDefs + parentPaths + paths;
   }


### PR DESCRIPTION
## Summary

- Keep raw Beads diagnostics out of Table and Graph views.
- Add explicit Start and End nodes to the task dependency graph.

## Changes

- Place AI write-capability diagnostics inside Manage while retaining disabled action guards.
- Permanently hide the raw parse-error container from the user-facing webview.
- Connect Start to visible roots and visible leaves to End, recalculating after filters.
- Add flow endpoint styling, boundary arrows, and graph model coverage.
- Bump the extension version to 0.6.1.

## Testing

- pnpm run lint
- pnpm run typecheck
- pnpm test (356 tests)
- pnpm run compile
- pnpm run package
- Packaged VSIX install and isolated Extension Host smoke
- Browser UI check for Table, Graph, Manage, Start/End nodes, and boundary lines

## Notes

- No Beads migration or bootstrap was performed.
- pnpm audit could not reach the npm registry in the sandbox; external audit access was not authorized.