### PR TITLE
feat(graph): focus current and ready work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Added
 
+- Focus a new Graph viewport on recorded in-progress and `bd ready` tasks while preserving saved
+  views, order Now/Next first in each visible dependency stage, and distinguish them in task cards
+  and the minimap.
+- Pulse only the recorded in-progress status dot, with a static reduced-motion fallback.
 - Let direct providers create or replace one declared workspace artifact through a bounded
   generation, verifier, and explicit human-review flow.
 - Add a dependency-linked Ollama smoke test for the nominal 0.5B `qwen2.5-coder:0.5b` model.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@ before approving an import or starting work.
 - Lets you switch between Git Graph and Beads from the toolbar
 - Lets you refresh, create, close, and sync Beads items inside VS Code
 - Shows optional parallel, AI provider/model, audit artifact, SSOT/context, worktree, branch, PR, check, and sync-risk hints on Beads items
-- Shows a Beads execution map with Critical Path, dependency arrows, dashed parent-child lines, merge/worktree risk, Start AI, Start Parallel, and merge actions
+- Shows a Beads execution map that focuses a new viewport on recorded in-progress and `bd ready`
+  work while preserving a saved viewport, with Critical Path, dependency arrows, dashed parent-child
+  lines, merge/worktree risk, Start AI, Start Parallel, and merge actions
 - Zooms the execution map around the location under the pointer, pans with normal drag, box-zooms
   with Option/Alt-drag, and preserves the transform when switching views, resizing, or refreshing
 - Refreshes task data in place without moving the visible area while preserving the selected view,

--- a/src/beadsProjectState.ts
+++ b/src/beadsProjectState.ts
@@ -5,6 +5,23 @@ export const AGENT_WORK_LANES = ["attention", "review", "running", "queue", "don
 
 export type AgentWorkLane = (typeof AGENT_WORK_LANES)[number];
 export type AgentWorkReadiness = "confirmed" | "not-confirmed" | "not-applicable";
+export type GraphWorkFocus = "running" | "next-ready" | "none";
+
+export function getGraphWorkFocusRank(focus: string | undefined) {
+  return focus === "running" ? 0 : focus === "next-ready" ? 1 : 2;
+}
+
+export function compareGraphWorkFocusOrder(
+  leftFocus: string | undefined,
+  leftId: string,
+  rightFocus: string | undefined,
+  rightId: string
+) {
+  return (
+    getGraphWorkFocusRank(leftFocus) - getGraphWorkFocusRank(rightFocus) ||
+    leftId.localeCompare(rightId)
+  );
+}
 
 export type AgentWorkReasonCode =
   | "blocked"
@@ -203,6 +220,17 @@ export function deriveAgentWorkItem(item: BeadItem): AgentWorkItem {
         };
 
   return makeDerivedItem(item, "queue", [queueReason], readiness);
+}
+
+export function deriveGraphWorkFocus(item: BeadItem): GraphWorkFocus {
+  const workItem = deriveAgentWorkItem(item);
+  if (workItem.lane === "running") {
+    return "running";
+  }
+  if (workItem.lane === "queue" && workItem.readiness === "confirmed") {
+    return "next-ready";
+  }
+  return "none";
 }
 
 export function buildAgentWorkQueue(items: BeadItem[]): AgentWorkQueue {

--- a/src/beadsWebview.ts
+++ b/src/beadsWebview.ts
@@ -23,7 +23,9 @@ import {
   AGENT_WORK_LANES,
   type AgentWorkItem,
   type AgentWorkLane,
-  buildAgentWorkQueue
+  buildAgentWorkQueue,
+  compareGraphWorkFocusOrder,
+  deriveGraphWorkFocus
 } from "./beadsProjectState";
 import { type BeadLoadResult } from "./beadsViewTypes";
 import { escapeHtml, getNonce } from "./utils";
@@ -156,6 +158,9 @@ function getExecutionStateLabel(item: BeadItem, normalizedStatus: string, derive
   }
   if (normalizedStatus === "closed") {
     return "Done";
+  }
+  if (normalizedStatus === "open" && item.readyByBd) {
+    return "Ready next";
   }
   if (
     (isCodingSessionProvider(item) && item.worktree.trim() !== "") ||
@@ -411,6 +416,15 @@ function renderBeadsDependencyGraph(
   const blocksById = new Map<string, string[]>();
   const itemsById = new Map(items.map((item) => [item.id, item]));
   const hierarchyById = new Map(hierarchyItems.map((entry) => [entry.item.id, entry]));
+  const graphWorkFocusById = new Map(
+    items.map((item) => [item.id, deriveGraphWorkFocus(item)] as const)
+  );
+  const runningCount = Array.from(graphWorkFocusById.values()).filter(
+    (focus) => focus === "running"
+  ).length;
+  const nextReadyCount = Array.from(graphWorkFocusById.values()).filter(
+    (focus) => focus === "next-ready"
+  ).length;
   const defaultVisibleIds = new Set(
     items
       .filter((item) => isDefaultVisibleStatus(normalizeBeadStatus(item.status)))
@@ -449,6 +463,16 @@ function renderBeadsDependencyGraph(
     const nodes = nodesByLevel.get(node.level) ?? [];
     nodes.push(node);
     nodesByLevel.set(node.level, nodes);
+  }
+  for (const nodes of nodesByLevel.values()) {
+    nodes.sort((left, right) =>
+      compareGraphWorkFocusOrder(
+        graphWorkFocusById.get(left.item.id),
+        left.item.id,
+        graphWorkFocusById.get(right.item.id),
+        right.item.id
+      )
+    );
   }
 
   const dependencyEdgeHtml = graph.edges
@@ -508,6 +532,7 @@ function renderBeadsDependencyGraph(
     return layout.nodes
       .map((node, lane) => {
         const item = node.item;
+        const graphWorkFocus = graphWorkFocusById.get(item.id) ?? "none";
         const column = Math.floor(lane / layout.rowCount);
         const row = lane % layout.rowCount;
         const x = layout.x + column * (GRAPH_NODE_WIDTH + GRAPH_LEVEL_COLUMN_GAP);
@@ -529,6 +554,12 @@ function renderBeadsDependencyGraph(
         const syncRiskLabel = item.syncRisk.trim();
         const derivedMerge = isDerivedMergeTask(item);
         const executionStateLabel = getExecutionStateLabel(item, normalizedStatus, derivedMerge);
+        const graphWorkBadge =
+          graphWorkFocus === "running"
+            ? '<span class="graphWorkBadge running" title="Beads records this task as in progress. Live agent activity is not confirmed."><span class="graphRunningDot" aria-hidden="true"></span>Now · Recorded</span>'
+            : graphWorkFocus === "next-ready"
+              ? '<span class="graphWorkBadge nextReady" title="bd ready confirms this open task can start now.">Next · Ready</span>'
+              : "";
         const dependencyWarning = dependencyWarnings.get(item.id) ?? "";
         const mergeRiskWarning = mergeRiskWarnings.get(item.id) ?? "";
         const blocks = (blocksById.get(item.id) ?? []).sort((a, b) => a.localeCompare(b));
@@ -563,7 +594,7 @@ function renderBeadsDependencyGraph(
           ? `<button class="mergeParallelPrs" type="button" data-merge-id="${escapeHtml(item.id)}" data-merge-workspace="${escapeHtml(workspacePath)}" data-merge-title="${escapeHtml(item.title)}" data-merge-dependencies="${escapeHtml(item.dependencyIds.join(","))}" title="${escapeHtml(writeAvailable ? "Check agent worktrees, auto-merge their PRs, then sync Beads." : writeUnavailableReason)}" aria-label="${escapeHtml(`Merge PRs for ${taskActionContext}`)}"${writeAvailable ? "" : " disabled"}>Merge PRs</button>`
           : `<button class="assignStartBead" type="button" data-assign-start-id="${escapeHtml(item.id)}" data-assign-start-workspace="${escapeHtml(workspacePath)}" data-assign-start-title="${escapeHtml(item.title)}" data-assign-start-agent="${escapeHtml(item.agent.trim())}" data-assign-start-provider="${escapeHtml(item.provider)}" data-assign-start-model="${escapeHtml(item.model.trim())}" data-assign-start-ssot="${escapeHtml(ssotLabel)}" data-assign-start-worktree="${escapeHtml(isCodingSessionProvider(item) ? item.worktree.trim() : "")}" title="${escapeHtml(assignTitle)}" aria-label="${escapeHtml(`Start AI for ${taskActionContext}`)}"${assignDisabled}>Start AI</button>`;
         const graphBadges = [
-          executionStateLabel === ""
+          executionStateLabel === "" || graphWorkFocus !== "none"
             ? ""
             : `<span class="executionBadge stateBadge">${escapeHtml(executionStateLabel)}</span>`,
           derivedMerge ? `<span class="executionBadge mergeBadge">Merge PR</span>` : "",
@@ -602,7 +633,7 @@ function renderBeadsDependencyGraph(
         ]
           .filter((badge) => badge !== "")
           .join("");
-        return `<div class="graphNode graphLayoutNode ${node.critical ? "criticalGraphNode" : ""}${node.cycle ? " cycleGraphNode" : ""}${dependencyWarning === "" ? "" : " dependencyWarningGraphNode"}${mergeRiskWarning === "" ? "" : " mergeRiskGraphNode"}" data-graph-id="${escapeHtml(item.id)}" data-graph-level="${level + 1}" data-graph-lane="${lane}" data-status="${escapeHtml(normalizedStatus)}" data-critical="${node.critical ? "1" : "0"}" data-cycle="${node.cycle ? "1" : "0"}" data-parent-id="${escapeHtml(parentId)}" data-epic-id="${escapeHtml(epicId ?? "")}" data-depth="${depth}" style="${initialDisplay}--graph-x:${x}px;--graph-y:${y}px"><div class="graphNodeTop"><span class="typeBadge type-${escapeHtml(normalizedType)}">${escapeHtml(item.type)}</span><span class="criticalBadge"${node.critical ? "" : " hidden"}>Longest chain</span><span class="cycleBadge"${node.cycle ? "" : " hidden"}>Cycle</span></div><div class="beadId">${escapeHtml(item.id)}</div><div class="graphNodeTitle">${escapeHtml(item.title)}</div><div class="graphNodeBadges"><span class="statusBadge status-${escapeHtml(normalizedStatus.replace(/_/g, "-"))}">${escapeHtml(beadStatusLabel(normalizedStatus))}</span><span class="priorityBadge priority-${escapeHtml(normalizedPriority.toLowerCase())}">${escapeHtml(normalizedPriority)}</span>${graphBadges}</div>${dependencyWarning === "" ? "" : `<div class="graphWarning">${escapeHtml(dependencyWarning)}</div>`}${mergeRiskWarning === "" ? "" : `<div class="graphWarning graphMergeRisk">${escapeHtml(mergeRiskWarning)}</div>`}${dependencyLines === "" ? "" : `<div class="graphRelations">${dependencyLines}</div>`}<div class="graphNodeActions"><button class="graphDetailsBead" type="button" data-graph-details-id="${escapeHtml(item.id)}" data-graph-details-workspace="${escapeHtml(workspacePath)}" aria-label="${escapeHtml(`Details for ${taskActionContext}`)}">Details</button>${actionHtml}</div></div>`;
+        return `<div class="graphNode graphLayoutNode ${graphWorkFocus === "running" ? "runningGraphNode " : graphWorkFocus === "next-ready" ? "nextReadyGraphNode " : ""}${node.critical ? "criticalGraphNode" : ""}${node.cycle ? " cycleGraphNode" : ""}${dependencyWarning === "" ? "" : " dependencyWarningGraphNode"}${mergeRiskWarning === "" ? "" : " mergeRiskGraphNode"}" data-graph-id="${escapeHtml(item.id)}" data-graph-level="${level + 1}" data-graph-lane="${lane}" data-status="${escapeHtml(normalizedStatus)}" data-work-focus="${graphWorkFocus}" data-critical="${node.critical ? "1" : "0"}" data-cycle="${node.cycle ? "1" : "0"}" data-parent-id="${escapeHtml(parentId)}" data-epic-id="${escapeHtml(epicId ?? "")}" data-depth="${depth}" style="${initialDisplay}--graph-x:${x}px;--graph-y:${y}px"><div class="graphNodeTop"><span class="typeBadge type-${escapeHtml(normalizedType)}">${escapeHtml(item.type)}</span>${graphWorkBadge}<span class="criticalBadge"${node.critical ? "" : " hidden"}>Longest chain</span><span class="cycleBadge"${node.cycle ? "" : " hidden"}>Cycle</span></div><div class="beadId">${escapeHtml(item.id)}</div><div class="graphNodeTitle">${escapeHtml(item.title)}</div><div class="graphNodeBadges"><span class="statusBadge status-${escapeHtml(normalizedStatus.replace(/_/g, "-"))}">${escapeHtml(beadStatusLabel(normalizedStatus))}</span><span class="priorityBadge priority-${escapeHtml(normalizedPriority.toLowerCase())}">${escapeHtml(normalizedPriority)}</span>${graphBadges}</div>${dependencyWarning === "" ? "" : `<div class="graphWarning">${escapeHtml(dependencyWarning)}</div>`}${mergeRiskWarning === "" ? "" : `<div class="graphWarning graphMergeRisk">${escapeHtml(mergeRiskWarning)}</div>`}${dependencyLines === "" ? "" : `<div class="graphRelations">${dependencyLines}</div>`}<div class="graphNodeActions"><button class="graphDetailsBead" type="button" data-graph-details-id="${escapeHtml(item.id)}" data-graph-details-workspace="${escapeHtml(workspacePath)}" aria-label="${escapeHtml(`Details for ${taskActionContext}`)}">Details</button>${actionHtml}</div></div>`;
       })
       .join("");
   }).join("");
@@ -637,6 +668,7 @@ function renderBeadsDependencyGraph(
           )
           .join("")}</div></details>`
       : "";
+  const graphWorkSummary = `<span class="summaryPill graphRunningSummary${runningCount === 0 ? " isEmpty" : ""}" aria-label="${runningCount} Now, recorded in progress; live activity is not confirmed" title="Beads records these tasks as in progress; this is not a live heartbeat"><span class="graphRunningDot" aria-hidden="true"></span><strong>${runningCount}</strong> Now (recorded)</span><span class="summaryPill graphNextSummary" title="Open tasks confirmed by bd ready"><strong>${nextReadyCount}</strong> Next</span>`;
   const criticalSummary = `<span class="summaryPill criticalSummary" title="${escapeHtml(graph.criticalPathIds.join(" -> "))}"${graph.criticalPathIds.length > 0 ? "" : " hidden"}>${graph.criticalPathIds.length} chain</span>`;
   const cycleSummary = `<span class="summaryPill cycleSummary"${graph.cycleIds.size > 0 ? "" : " hidden"}>${graph.cycleIds.size} cycle</span>`;
   const pathUnavailable = graph.cycleIds.size > 0;
@@ -647,10 +679,10 @@ function renderBeadsDependencyGraph(
       : "No dependency path yet";
   const criticalPathHtml = `<div class="graphPathStrip${graph.criticalPathIds.length > 0 ? "" : " emptyCriticalPath"}${pathUnavailable ? " cycleGraphPath" : ""}"><span>Longest Chain</span><strong class="graphPathValue" title="${escapeHtml(pathText)}">${escapeHtml(pathText)}</strong></div>`;
   const graphLegendHtml =
-    '<div class="graphLegend"><span class="flowLegend">Visible flow</span><span class="dependencyLegend">Dependency</span><span class="criticalLegend">Longest chain</span><span class="cycleLegend">Cycle</span><span class="parentLegend">Parent</span><span class="riskLegend">Merge/worktree risk</span></div>';
+    '<div class="graphLegend"><span class="runningLegend">Now (recorded)</span><span class="nextReadyLegend">Next ready</span><span class="flowLegend">Visible flow</span><span class="dependencyLegend">Dependency</span><span class="criticalLegend">Longest chain</span><span class="cycleLegend">Cycle</span><span class="parentLegend">Parent</span><span class="riskLegend">Merge/worktree risk</span></div>';
   const graphIssuesHtml = `<div class="graphIssueStack">${dependencyWarningHtml}${mergeRiskHtml}</div>`;
 
-  return `<div class="graphPane" data-workspace-path="${escapeHtml(workspacePath)}"><div class="graphHeader"><div><div class="workspaceName">Execution Map</div><div class="graphGestureHint">Point anywhere and wheel to zoom there · Drag to pan · Option/Alt+drag a box to zoom · Double-click to fit</div></div><div class="graphHeaderActions"><div class="workspaceSummary"><span class="summaryPill dependencySummary">${graph.edges.length} deps</span>${criticalSummary}${cycleSummary}${dependencyWarningSummary}${mergeRiskSummary}</div><div class="graphControls" role="group" aria-label="Graph zoom controls"><button type="button" data-graph-action="out" title="Zoom out" aria-label="Zoom out">−</button><span class="graphZoomValue" aria-live="polite">100%</span><button type="button" data-graph-action="in" title="Zoom in" aria-label="Zoom in">+</button><button type="button" data-graph-action="fit">Fit</button></div></div></div>${graphIssuesHtml}<div class="graphMapFrame"><div class="graphMapHeader"><div class="graphMapHeaderMain">${criticalPathHtml}${graphLegendHtml}</div><svg class="graphMiniMap" role="img" aria-label="Graph overview. The outlined rectangle is the current viewport."></svg></div><div class="graphScroller" tabindex="0" aria-label="Dependency graph. Point anywhere and wheel to zoom around that location. Drag to pan, Option or Alt drag a box to zoom, use arrow keys to pan, and press zero to fit."><div class="graphCanvas" data-graph-width="${graphWidth}" data-graph-height="${graphHeight}" style="width:${graphWidth}px;height:${graphHeight}px"><div class="graphContent" style="width:${graphWidth}px;height:${graphHeight}px;--graph-node-width:${GRAPH_NODE_WIDTH}px">${edgeHtml}<svg class="dependencyOverlay" aria-hidden="true"></svg>${levelGuideHtml}<div class="graphNodes">${boundaryNodeHtml}${nodeHtml}</div></div></div><div class="graphZoomSelection" hidden></div></div></div></div>`;
+  return `<div class="graphPane" data-workspace-path="${escapeHtml(workspacePath)}"><div class="graphHeader"><div><div class="workspaceName">Execution Map</div><div class="graphGestureHint">A new viewport focuses Now/Next; saved views keep their position · Point anywhere and wheel to zoom there · Drag to pan · Option/Alt+drag a box to zoom · Double-click to fit all</div></div><div class="graphHeaderActions"><div class="workspaceSummary">${graphWorkSummary}<span class="summaryPill dependencySummary">${graph.edges.length} deps</span>${criticalSummary}${cycleSummary}${dependencyWarningSummary}${mergeRiskSummary}</div><div class="graphControls" role="group" aria-label="Graph zoom controls"><button type="button" data-graph-action="out" title="Zoom out" aria-label="Zoom out">−</button><span class="graphZoomValue" aria-live="polite">100%</span><button type="button" data-graph-action="in" title="Zoom in" aria-label="Zoom in">+</button><button type="button" data-graph-action="focus" title="Center recorded in-progress and ready-next tasks"${runningCount + nextReadyCount === 0 ? " disabled" : ""}>Focus</button><button type="button" data-graph-action="fit">Fit all</button></div></div></div>${graphIssuesHtml}<div class="graphMapFrame"><div class="graphMapHeader"><div class="graphMapHeaderMain">${criticalPathHtml}${graphLegendHtml}</div><svg class="graphMiniMap" role="img" aria-label="Graph overview. The outlined rectangle is the current viewport."></svg></div><div class="graphScroller" tabindex="0" aria-label="Dependency graph. Point anywhere and wheel to zoom around that location. Drag to pan, Option or Alt drag a box to zoom, use arrow keys to pan, press F to focus Now and Next, and press zero to fit all."><div class="graphCanvas" data-graph-width="${graphWidth}" data-graph-height="${graphHeight}" style="width:${graphWidth}px;height:${graphHeight}px"><div class="graphContent" style="width:${graphWidth}px;height:${graphHeight}px;--graph-node-width:${GRAPH_NODE_WIDTH}px">${edgeHtml}<svg class="dependencyOverlay" aria-hidden="true"></svg>${levelGuideHtml}<div class="graphNodes">${boundaryNodeHtml}${nodeHtml}</div></div></div><div class="graphZoomSelection" hidden></div></div></div></div>`;
 }
 
 export function renderBeadsWebviewHtml(
@@ -1247,6 +1279,10 @@ th:nth-child(1){width:52px;}th:nth-child(2){width:72px;}th:nth-child(4){width:78
 .graphControls button{min-width:24px;height:22px;padding:0 6px;background:transparent;color:var(--vscode-foreground);}
 .graphControls button:hover{background:rgba(128,128,128,.18);}
 .graphZoomValue{min-width:38px;text-align:center;color:var(--vscode-descriptionForeground);font-size:10px;font-variant-numeric:tabular-nums;}
+.graphRunningSummary{border-color:rgba(59,130,246,.62);color:var(--vscode-textLink-foreground,#3b82f6);}
+.graphRunningSummary.isEmpty .graphRunningDot{display:none;animation:none;}
+.graphNextSummary{border-color:rgba(34,197,94,.62);color:var(--vscode-testing-iconPassed,#22c55e);}
+.graphRunningSummary strong,.graphNextSummary strong{font-variant-numeric:tabular-nums;}
 .criticalSummary{border-color:rgba(236,72,153,.5);color:var(--vscode-charts-pink,#ec4899);}
 .cycleSummary{border-color:rgba(168,85,247,.55);color:var(--vscode-charts-purple,#a855f7);}
 .dependencyWarningSummary{border-color:rgba(245,158,11,.55);color:var(--vscode-editorWarning-foreground,#f59e0b);}
@@ -1275,6 +1311,10 @@ th:nth-child(1){width:52px;}th:nth-child(2){width:72px;}th:nth-child(4){width:78
 .graphMiniMapEdge.cycle{stroke:var(--vscode-charts-purple,#a855f7);stroke-width:1.8;}
 .graphMiniMapNode{fill:color-mix(in srgb,var(--vscode-foreground) 36%,transparent);stroke:var(--vscode-panel-border);stroke-width:1;vector-effect:non-scaling-stroke;}
 .graphMiniMapNode.boundary{fill:color-mix(in srgb,var(--vscode-textLink-foreground,#3b82f6) 52%,transparent);}
+.graphMiniMapNode.running{stroke:var(--vscode-textLink-foreground,#3b82f6);stroke-width:2;}
+.graphMiniMapNode.nextReady{stroke:var(--vscode-testing-iconPassed,#22c55e);stroke-width:2;}
+.graphMiniMapNode.running:not(.chain):not(.cycle){fill:color-mix(in srgb,var(--vscode-textLink-foreground,#3b82f6) 55%,transparent);}
+.graphMiniMapNode.nextReady:not(.chain):not(.cycle){fill:color-mix(in srgb,var(--vscode-testing-iconPassed,#22c55e) 48%,transparent);}
 .graphMiniMapNode.chain{fill:color-mix(in srgb,var(--vscode-charts-pink,#ec4899) 65%,transparent);}
 .graphMiniMapNode.cycle{fill:color-mix(in srgb,var(--vscode-charts-purple,#a855f7) 65%,transparent);}
 .graphMiniMapViewport{fill:color-mix(in srgb,var(--vscode-focusBorder,#3b82f6) 12%,transparent);stroke:var(--vscode-focusBorder,#3b82f6);stroke-width:2;vector-effect:non-scaling-stroke;}
@@ -1286,6 +1326,9 @@ th:nth-child(1){width:52px;}th:nth-child(2){width:72px;}th:nth-child(4){width:78
 .graphLegend{display:flex;flex-wrap:wrap;justify-content:flex-end;gap:6px;margin:0;}
 .graphLegend span{display:inline-flex;align-items:center;gap:5px;min-height:18px;padding:1px 7px;border-radius:999px;border:1px solid var(--vscode-panel-border);font-size:10px;font-weight:700;color:var(--vscode-descriptionForeground);background:rgba(128,128,128,.08);}
 .graphLegend span::before{content:"";width:14px;height:0;border-top:2px solid currentColor;}
+.runningLegend{color:var(--vscode-textLink-foreground,#3b82f6)!important;}
+.nextReadyLegend{color:var(--vscode-testing-iconPassed,#22c55e)!important;}
+.runningLegend::before,.nextReadyLegend::before{width:8px!important;height:8px!important;border:0!important;border-radius:999px;background:currentColor;}
 .flowLegend{color:var(--vscode-textLink-foreground,#3b82f6)!important;}
 .dependencyLegend{color:rgba(148,163,184,.95)!important;}
 .criticalLegend{color:var(--vscode-charts-pink,#ec4899)!important;}
@@ -1321,6 +1364,13 @@ th:nth-child(1){width:52px;}th:nth-child(2){width:72px;}th:nth-child(4){width:78
 .graphLevelLabel small{font-size:10px;font-weight:650;line-height:1.15;color:var(--vscode-descriptionForeground);}
 .graphNodes{position:absolute;inset:0;z-index:2;}
 .graphNode{box-sizing:border-box;position:absolute;left:var(--graph-x);top:var(--graph-y);width:var(--graph-node-width,280px);border:1px solid var(--vscode-panel-border);border-radius:8px;background:var(--vscode-sideBar-background,var(--vscode-editor-background));padding:8px;box-shadow:0 1px 3px rgba(0,0,0,.12);}
+.graphNode.runningGraphNode{outline:2px solid var(--vscode-textLink-foreground,#3b82f6);outline-offset:2px;}
+.graphNode.nextReadyGraphNode{outline:2px solid var(--vscode-testing-iconPassed,#22c55e);outline-offset:2px;}
+@keyframes graphRunningPulse{0%,100%{opacity:.32;}50%{opacity:1;}}
+.graphRunningDot{display:inline-block;flex:0 0 8px;width:8px;height:8px;border-radius:999px;background:currentColor;box-shadow:0 0 0 2px color-mix(in srgb,currentColor 18%,transparent);animation:graphRunningPulse 1.8s ease-in-out infinite;}
+.graphWorkBadge{display:inline-flex;align-items:center;gap:5px;min-height:17px;padding:1px 6px;border-radius:999px;font-size:10px;font-weight:800;white-space:nowrap;}
+.graphWorkBadge.running{border:1px solid rgba(59,130,246,.62);background:rgba(59,130,246,.14);color:var(--vscode-textLink-foreground,#3b82f6);}
+.graphWorkBadge.nextReady{border:1px solid rgba(34,197,94,.62);background:rgba(34,197,94,.14);color:var(--vscode-testing-iconPassed,#22c55e);}
 .graphBoundaryNode{box-sizing:border-box;position:absolute;left:var(--graph-x);top:var(--graph-y);display:grid;grid-template-columns:32px 1fr;grid-template-rows:auto auto;column-gap:9px;align-items:center;width:var(--graph-node-width,280px);min-height:62px;padding:9px 12px;border:1px solid var(--vscode-focusBorder,var(--vscode-textLink-foreground,#3b82f6));border-radius:999px;background:color-mix(in srgb,var(--vscode-textLink-foreground,#3b82f6) 12%,var(--vscode-editor-background));box-shadow:0 2px 8px rgba(0,0,0,.15);}
 .graphBoundaryIcon{grid-row:1 / 3;display:grid;place-items:center;width:30px;height:30px;border-radius:999px;background:var(--vscode-textLink-foreground,#3b82f6);color:var(--vscode-button-foreground,#fff);font-size:13px;font-weight:800;}
 .graphBoundaryNode strong{font-size:13px;line-height:1.2;}
@@ -1400,6 +1450,9 @@ th:nth-child(1){width:52px;}th:nth-child(2){width:72px;}th:nth-child(4){width:78
 .planMutationPreview ol{display:grid;gap:7px;margin:8px 0 0;padding-left:22px;}
 .planMutationPreview li span{display:inline-block;min-width:95px;font-size:10px;font-weight:750;text-transform:uppercase;color:var(--vscode-descriptionForeground);}
 .planMutationPreview code{display:block;margin-top:2px;overflow-wrap:anywhere;white-space:pre-wrap;}
+@media (prefers-reduced-motion:reduce){
+  .graphRunningDot{animation:none;opacity:1;}
+}
 @media (max-width:560px){
   .toolbar{grid-template-columns:1fr;gap:6px;}
   .toolbarActions{justify-content:stretch;}

--- a/tests/beadsMissionControlWebview.test.ts
+++ b/tests/beadsMissionControlWebview.test.ts
@@ -68,6 +68,14 @@ function getAgentCard(html: string, issueId: string) {
   return getTagContaining(html, "article", `data-work-item-id="${issueId}"`);
 }
 
+function getGraphNodeOpeningTag(html: string, issueId: string) {
+  const tag = html
+    .match(/<div\b[^>]*class="graphNode graphLayoutNode [^"]*"[^>]*>/g)
+    ?.find((candidate) => candidate.includes(`data-graph-id="${issueId}"`));
+  expect(tag, `Expected a Graph node for ${issueId}`).toBeDefined();
+  return tag ?? "";
+}
+
 function supportedCapabilities(workspace: string, workspacePath: string) {
   const capability = {
     supported: true,
@@ -546,6 +554,91 @@ describe("Agent Project Manager webview", () => {
     expect(html).toContain(
       `<section data-workspace-path="${workspacePath}" data-write-available="1" data-write-unavailable-reason="">`
     );
+  });
+
+  it("puts recorded work and bd-ready tasks first in the Graph without pulsing review work", () => {
+    const workspacePath = "/tmp/mission-control";
+    const html = renderBeadsWebviewHtml(
+      {
+        cspSource: "vscode-webview:",
+        asWebviewUri: () => ({ toString: () => "vscode-webview:/out/beadsWebview.min.js" })
+      } as never,
+      { path: "/extension" } as never,
+      {
+        groups: [
+          {
+            workspace: "Mission Control",
+            workspacePath,
+            items: [
+              makeBead({ id: "unready", parallelizable: true }),
+              makeBead({
+                id: "review-response",
+                status: "in_progress",
+                provider: "openai",
+                artifact: "beads-response:00000000-0000-4000-8000-000000000000"
+              }),
+              makeBead({ id: "review-pr", status: "in_progress", pullRequest: "#42" }),
+              makeBead({ id: "next", readyByBd: true, model: "small-model", priority: "P1" }),
+              makeBead({ id: "working", status: "in_progress", priority: "P2" })
+            ]
+          }
+        ],
+        emptyWorkspaces: [],
+        unavailableWorkspaces: [],
+        bdExecutableStatus: { available: true, command: "bd", message: null },
+        ...supportedCapabilities("Mission Control", workspacePath),
+        errors: [],
+        warnings: []
+      }
+    );
+
+    expect(getGraphNodeOpeningTag(html, "working")).toContain("runningGraphNode");
+    expect(getGraphNodeOpeningTag(html, "working")).toContain('data-work-focus="running"');
+    expect(getGraphNodeOpeningTag(html, "next")).toContain("nextReadyGraphNode");
+    expect(getGraphNodeOpeningTag(html, "next")).toContain('data-work-focus="next-ready"');
+    expect(getGraphNodeOpeningTag(html, "review-pr")).toContain('data-work-focus="none"');
+    expect(getGraphNodeOpeningTag(html, "review-response")).toContain('data-work-focus="none"');
+    expect(getGraphNodeOpeningTag(html, "unready")).toContain('data-work-focus="none"');
+    expect(html).toContain("Now · Recorded");
+    expect(html).toContain("Next · Ready");
+    expect(html).toContain("<strong>1</strong> Now");
+    expect(html).toContain("<strong>1</strong> Next");
+    expect(html.indexOf('data-graph-id="working"')).toBeLessThan(
+      html.indexOf('data-graph-id="next"')
+    );
+    expect(html.indexOf('data-graph-id="next"')).toBeLessThan(
+      html.indexOf('data-graph-id="review-pr"')
+    );
+  });
+
+  it("does not pulse the Now summary when no recorded work is visible", () => {
+    const workspacePath = "/tmp/mission-control";
+    const html = renderBeadsWebviewHtml(
+      {
+        cspSource: "vscode-webview:",
+        asWebviewUri: () => ({ toString: () => "vscode-webview:/out/beadsWebview.min.js" })
+      } as never,
+      { path: "/extension" } as never,
+      {
+        groups: [
+          {
+            workspace: "Mission Control",
+            workspacePath,
+            items: [makeBead({ id: "next", readyByBd: true })]
+          }
+        ],
+        emptyWorkspaces: [],
+        unavailableWorkspaces: [],
+        bdExecutableStatus: { available: true, command: "bd", message: null },
+        ...supportedCapabilities("Mission Control", workspacePath),
+        errors: [],
+        warnings: []
+      }
+    );
+
+    expect(html).toContain('class="summaryPill graphRunningSummary isEmpty"');
+    expect(html).toContain("<strong>0</strong> Now (recorded)");
+    expect(html).toContain(".graphRunningSummary.isEmpty .graphRunningDot{display:none");
   });
 
   it("moves a linked cross-model handoff from upstream work to the downstream queue", () => {

--- a/tests/beadsProjectState.test.ts
+++ b/tests/beadsProjectState.test.ts
@@ -4,7 +4,9 @@ import { type BeadItem } from "../src/beadsData";
 import {
   AGENT_WORK_LANES,
   buildAgentWorkQueue,
-  deriveAgentWorkItem
+  compareGraphWorkFocusOrder,
+  deriveAgentWorkItem,
+  deriveGraphWorkFocus
 } from "../src/beadsProjectState";
 
 function makeBead(overrides: Partial<BeadItem> = {}): BeadItem {
@@ -173,6 +175,52 @@ describe("deriveAgentWorkItem", () => {
     expect(
       deriveAgentWorkItem(makeBead({ checkStatus: "pending", syncRisk: "medium" }))
     ).toMatchObject({ lane: "queue" });
+  });
+});
+
+describe("deriveGraphWorkFocus", () => {
+  it("marks only ordinary recorded in-progress work as running", () => {
+    expect(deriveGraphWorkFocus(makeBead({ status: "in_progress" }))).toBe("running");
+    expect(deriveGraphWorkFocus(makeBead({ status: "in_progress", pullRequest: "#42" }))).toBe(
+      "none"
+    );
+    expect(
+      deriveGraphWorkFocus(
+        makeBead({
+          status: "in_progress",
+          provider: "openai",
+          artifact: "beads-response:00000000-0000-4000-8000-000000000000"
+        })
+      )
+    ).toBe("none");
+    expect(deriveGraphWorkFocus(makeBead({ status: "in_progress", checkStatus: "failed" }))).toBe(
+      "none"
+    );
+  });
+
+  it("marks only bd-confirmed open work as next ready", () => {
+    expect(deriveGraphWorkFocus(makeBead({ status: "open", readyByBd: true }))).toBe("next-ready");
+    expect(
+      deriveGraphWorkFocus(makeBead({ status: "open", parallelizable: true, readyByBd: false }))
+    ).toBe("none");
+  });
+
+  it("orders Now and Next before other tasks after visible levels are projected", () => {
+    const projected = [
+      { id: "unready", level: 0, focus: "none" },
+      { id: "ready-after-hidden-dependency", level: 0, focus: "next-ready" },
+      { id: "working", level: 0, focus: "running" }
+    ].sort(
+      (left, right) =>
+        left.level - right.level ||
+        compareGraphWorkFocusOrder(left.focus, left.id, right.focus, right.id)
+    );
+
+    expect(projected.map((item) => item.id)).toEqual([
+      "working",
+      "ready-after-hidden-dependency",
+      "unready"
+    ]);
   });
 });
 

--- a/tests/beadsWebviewMetadata.test.ts
+++ b/tests/beadsWebviewMetadata.test.ts
@@ -93,6 +93,36 @@ describe("beads webview presentation metadata", () => {
     expect(beadsWebview).toContain("cycleLegend");
     expect(beadsWebview).toContain("parentLegend");
     expect(beadsWebview).toContain("riskLegend");
+    expect(beadsWebview).toContain("runningLegend");
+    expect(beadsWebview).toContain("nextReadyLegend");
+    expect(beadsWebview).toContain("deriveGraphWorkFocus");
+    expect(beadsWebview).toContain('data-work-focus="');
+    expect(beadsWebview).toContain("graphWorkFocus");
+    expect(beadsWebview).toContain("runningGraphNode");
+    expect(beadsWebview).toContain("nextReadyGraphNode");
+    expect(beadsWebview).toContain("Now · Recorded");
+    expect(beadsWebview).toContain("Next · Ready");
+    expect(beadsWebview).toContain(
+      "@keyframes graphRunningPulse{0%,100%{opacity:.32;}50%{opacity:1;}}"
+    );
+    expect(beadsWebview).toContain("@media (prefers-reduced-motion:reduce)");
+    expect(beadsWebview).toContain(".graphRunningDot{animation:none;opacity:1;}");
+    expect(beadsWebview).toContain(
+      ".graphRunningSummary.isEmpty .graphRunningDot{display:none;animation:none;}"
+    );
+    expect(beadsWebview).toContain(".graphMiniMapNode.running:not(.chain):not(.cycle)");
+    expect(beadsWebview).toContain(".graphMiniMapNode.nextReady:not(.chain):not(.cycle)");
+    expect(beadsWebview).toContain('data-graph-action="focus"');
+    expect(beadsMain).toContain("focusGraphWorkToPane");
+    expect(beadsMain).toContain("computeGraphFitTransformForRect");
+    expect(beadsMain).toContain("captureGraphRenderNodeAnchor");
+    expect(beadsMain).toContain('document.querySelectorAll<HTMLElement>(".graphScroller")');
+    expect(beadsMain).toContain("for (const graphNode of anchor.graphNodes)");
+    expect(beadsMain).toContain("computeGraphPanForStableAnchor");
+    expect(beadsMain).toContain("compareGraphWorkFocusOrder");
+    expect(beadsMain).toContain('runningSummary.classList.toggle("isEmpty"');
+    expect(beadsMain).toContain('node.dataset.workFocus === "running"');
+    expect(beadsMain).toContain('node.dataset.workFocus === "next-ready"');
     expect(beadsWebview).toContain("dependencyOverlay");
     expect(beadsWebview).toContain("criticalGraphNode");
     expect(beadsWebview).toContain("cycleGraphNode");

--- a/tests/graphViewportTransform.test.ts
+++ b/tests/graphViewportTransform.test.ts
@@ -4,6 +4,8 @@ import {
   clampGraphPanForVisibility,
   computeAnchoredGraphPan,
   computeCenteredGraphPan,
+  computeGraphFitTransformForRect,
+  computeGraphPanForStableAnchor,
   computeGraphPanToCenterRect,
   computeGraphPanToRevealRect,
   getGraphPointerGesture,
@@ -91,6 +93,31 @@ describe("graph viewport transforms", () => {
     expect(
       computeCenteredGraphPan({ width: 1_000, height: 700 }, { width: 760, height: 420 })
     ).toEqual({ x: 120, y: 140 });
+  });
+
+  it("keeps the same task at the same screen position after a layout reorder", () => {
+    expect(
+      computeGraphPanForStableAnchor({ x: -320, y: 80 }, { x: 140, y: 120 }, { x: 460, y: 40 })
+    ).toEqual({ x: -640, y: 160 });
+  });
+
+  it("fits and centers a work-focus group without zooming above 100 percent", () => {
+    const focused = computeGraphFitTransformForRect(
+      { width: 1_000, height: 700 },
+      { x: 800, y: 300, width: 2_000, height: 500 },
+      16
+    );
+    expect(focused.zoom).toBeCloseTo(0.484);
+    expect(focused.pan.x).toBeCloseTo(-371.2);
+    expect(focused.pan.y).toBeCloseTo(83.8);
+
+    expect(
+      computeGraphFitTransformForRect(
+        { width: 1_000, height: 700 },
+        { x: 800, y: 300, width: 252, height: 160 },
+        16
+      ).zoom
+    ).toBe(1);
   });
 
   it("recenters a surviving filtered group without changing zoom", () => {

--- a/web/beadsMain.ts
+++ b/web/beadsMain.ts
@@ -16,6 +16,7 @@ import {
   graphEdgeKey,
   partitionGraphRelationIds
 } from "../src/beadsGraphModel";
+import { compareGraphWorkFocusOrder } from "../src/beadsProjectState";
 import {
   type BeadsHostMessage,
   type BeadsRequestMessage,
@@ -34,6 +35,8 @@ import {
   clampGraphPanForVisibility,
   computeAnchoredGraphPan,
   computeCenteredGraphPan,
+  computeGraphFitTransformForRect,
+  computeGraphPanForStableAnchor,
   computeGraphPanToCenterRect,
   computeGraphPanToRevealRect,
   getGraphPointerGesture,
@@ -72,12 +75,19 @@ type GraphPanGestureState = {
   startPan: GraphPanState;
 };
 type SelectedIssueState = { workspacePath: string; issueId: string };
+type GraphRenderNodeAnchor = {
+  workspacePath: string;
+  issueId: string;
+  relativeLeft: number;
+  relativeTop: number;
+};
 type RenderViewportAnchor = {
   element: HTMLElement | null;
   elementTop: number;
   fallbackScrollX: number;
   fallbackScrollY: number;
   graphDetailsScrollTop: number | null;
+  graphNodes: GraphRenderNodeAnchor[];
 };
 type BeadsWebviewState = {
   viewMode?: ViewMode;
@@ -1065,19 +1075,136 @@ function getRenderViewportElement() {
   return document.querySelector<HTMLElement>("#planDraftView");
 }
 
+function captureGraphRenderNodeAnchor(element: HTMLElement | null): GraphRenderNodeAnchor | null {
+  if (
+    activeViewMode !== "graph" ||
+    element === null ||
+    !element.classList.contains("graphScroller")
+  ) {
+    return null;
+  }
+  const pane = element.closest<HTMLElement>(".graphPane");
+  if (pane === null) {
+    return null;
+  }
+  const frame = element.getBoundingClientRect();
+  const candidates = Array.from(
+    pane.querySelectorAll<HTMLElement>(".graphNode[data-graph-id]")
+  ).filter((node) => {
+    if (node.hidden || node.style.display === "none" || node.offsetParent === null) {
+      return false;
+    }
+    const rect = node.getBoundingClientRect();
+    return (
+      rect.right > frame.left &&
+      rect.left < frame.right &&
+      rect.bottom > frame.top &&
+      rect.top < frame.bottom
+    );
+  });
+  if (candidates.length === 0) {
+    return null;
+  }
+  const selectedIssue = getSelectedIssue();
+  const selectedNode = candidates.find(
+    (node) =>
+      selectedIssue?.workspacePath === getGraphWorkspaceKey(pane) &&
+      node.dataset.graphId === selectedIssue.issueId
+  );
+  const centerX = frame.left + frame.width / 2;
+  const centerY = frame.top + frame.height / 2;
+  const node =
+    selectedNode ??
+    candidates.sort((left, right) => {
+      const leftRect = left.getBoundingClientRect();
+      const rightRect = right.getBoundingClientRect();
+      const leftDistance =
+        Math.abs(leftRect.left + leftRect.width / 2 - centerX) +
+        Math.abs(leftRect.top + leftRect.height / 2 - centerY);
+      const rightDistance =
+        Math.abs(rightRect.left + rightRect.width / 2 - centerX) +
+        Math.abs(rightRect.top + rightRect.height / 2 - centerY);
+      return leftDistance - rightDistance;
+    })[0];
+  const rect = node.getBoundingClientRect();
+  return {
+    workspacePath: getGraphWorkspaceKey(pane),
+    issueId: node.dataset.graphId || "",
+    relativeLeft: rect.left - frame.left,
+    relativeTop: rect.top - frame.top
+  };
+}
+
 function captureRenderViewportAnchor(): RenderViewportAnchor {
   const element = getRenderViewportElement();
+  const graphNodes =
+    activeViewMode === "graph"
+      ? Array.from(document.querySelectorAll<HTMLElement>(".graphScroller"))
+          .map((scroller) => captureGraphRenderNodeAnchor(scroller))
+          .filter((anchor): anchor is GraphRenderNodeAnchor => anchor !== null)
+      : [];
   return {
     element,
     elementTop: element?.getBoundingClientRect().top ?? 0,
     fallbackScrollX: window.scrollX,
     fallbackScrollY: window.scrollY,
     graphDetailsScrollTop:
-      document.querySelector<HTMLElement>(".graphSelectedDetails")?.scrollTop ?? null
+      document.querySelector<HTMLElement>(".graphSelectedDetails")?.scrollTop ?? null,
+    graphNodes
   };
 }
 
+function restoreGraphRenderNodeAnchor(anchor: GraphRenderNodeAnchor | null) {
+  if (anchor === null) {
+    return;
+  }
+  const pane = Array.from(document.querySelectorAll<HTMLElement>(".graphPane")).find(
+    (candidate) => getGraphWorkspaceKey(candidate) === anchor.workspacePath
+  );
+  const scroller = pane === undefined ? null : getGraphScroller(pane);
+  const node =
+    pane === undefined
+      ? undefined
+      : Array.from(pane.querySelectorAll<HTMLElement>(".graphNode[data-graph-id]")).find(
+          (candidate) => candidate.dataset.graphId === anchor.issueId
+        );
+  if (
+    pane === undefined ||
+    scroller === null ||
+    node === undefined ||
+    node.hidden ||
+    node.style.display === "none" ||
+    node.offsetParent === null
+  ) {
+    return;
+  }
+  const frame = scroller.getBoundingClientRect();
+  const rect = node.getBoundingClientRect();
+  const transform = getGraphTransform(pane);
+  const nextPan = clampGraphPanForPane(
+    pane,
+    computeGraphPanForStableAnchor(
+      transform.pan,
+      { x: anchor.relativeLeft, y: anchor.relativeTop },
+      { x: rect.left - frame.left, y: rect.top - frame.top }
+    ),
+    transform.zoom
+  );
+  if (
+    Math.abs(nextPan.x - transform.pan.x) <= 0.5 &&
+    Math.abs(nextPan.y - transform.pan.y) <= 0.5
+  ) {
+    return;
+  }
+  setGraphTransform(pane, { ...transform, pan: nextPan });
+  applyGraphZoomToPane(pane);
+  saveGraphTransforms();
+}
+
 function restoreRenderViewportAnchor(anchor: RenderViewportAnchor) {
+  for (const graphNode of anchor.graphNodes) {
+    restoreGraphRenderNodeAnchor(graphNode);
+  }
   const details = document.querySelector<HTMLElement>(".graphSelectedDetails");
   if (details !== null && anchor.graphDetailsScrollTop !== null) {
     details.scrollTop = anchor.graphDetailsScrollTop;
@@ -2065,6 +2192,12 @@ function getVisibleGraphLayoutNodes(pane: HTMLElement) {
   );
 }
 
+function getGraphWorkFocusNodes(pane: HTMLElement) {
+  return getVisibleGraphNodes(pane).filter(
+    (node) => node.dataset.workFocus === "running" || node.dataset.workFocus === "next-ready"
+  );
+}
+
 function updateGraphIssueDrawer(
   pane: HTMLElement,
   drawerSelector: string,
@@ -2190,6 +2323,33 @@ function refreshGraphDerivedState(pane: HTMLElement) {
       : "0";
   }
 
+  const visibleRunningCount = visibleNodes.filter(
+    (node) => node.dataset.workFocus === "running"
+  ).length;
+  const visibleNextReadyCount = visibleNodes.filter(
+    (node) => node.dataset.workFocus === "next-ready"
+  ).length;
+  const runningSummaryCount = pane.querySelector<HTMLElement>(".graphRunningSummary strong");
+  const nextSummaryCount = pane.querySelector<HTMLElement>(".graphNextSummary strong");
+  if (runningSummaryCount !== null) {
+    runningSummaryCount.textContent = String(visibleRunningCount);
+  }
+  const runningSummary = pane.querySelector<HTMLElement>(".graphRunningSummary");
+  if (runningSummary !== null) {
+    runningSummary.classList.toggle("isEmpty", visibleRunningCount === 0);
+    runningSummary.setAttribute(
+      "aria-label",
+      `${visibleRunningCount} Now, recorded in progress; live activity is not confirmed`
+    );
+  }
+  if (nextSummaryCount !== null) {
+    nextSummaryCount.textContent = String(visibleNextReadyCount);
+  }
+  const focusButton = pane.querySelector<HTMLButtonElement>('button[data-graph-action="focus"]');
+  if (focusButton !== null) {
+    focusButton.disabled = visibleRunningCount + visibleNextReadyCount === 0;
+  }
+
   const dependencySummary = pane.querySelector<HTMLElement>(".dependencySummary");
   if (dependencySummary !== null) {
     dependencySummary.textContent = `${graphState.edges.length} deps`;
@@ -2251,7 +2411,20 @@ function layoutGraphPane(pane: HTMLElement) {
   if (canvas === null || content === null || pane.offsetParent === null) {
     return;
   }
-  const visibleNodes = getVisibleGraphLayoutNodes(pane);
+  const visibleNodes = getVisibleGraphLayoutNodes(pane).sort((left, right) => {
+    const levelDifference =
+      Number.parseInt(left.dataset.graphLevel || "0", 10) -
+      Number.parseInt(right.dataset.graphLevel || "0", 10);
+    return (
+      levelDifference ||
+      compareGraphWorkFocusOrder(
+        left.dataset.workFocus,
+        left.dataset.graphId || "",
+        right.dataset.workFocus,
+        right.dataset.graphId || ""
+      )
+    );
+  });
   const layout = computePackedGraphLayout(
     visibleNodes.map((node) => ({
       id: node.dataset.graphId || "",
@@ -2470,16 +2643,22 @@ function renderGraphMiniMap(pane: HTMLElement) {
     element.setAttribute("y", String(rect.y));
     element.setAttribute("width", String(rect.width));
     element.setAttribute("height", String(rect.height));
-    element.setAttribute(
-      "class",
-      node.classList.contains("graphBoundaryNode")
-        ? "graphMiniMapNode boundary"
-        : node.dataset.cycle === "1"
-          ? "graphMiniMapNode cycle"
-          : node.dataset.critical === "1"
-            ? "graphMiniMapNode chain"
-            : "graphMiniMapNode"
-    );
+    const nodeClasses = ["graphMiniMapNode"];
+    if (node.classList.contains("graphBoundaryNode")) {
+      nodeClasses.push("boundary");
+    } else {
+      if (node.dataset.workFocus === "running") {
+        nodeClasses.push("running");
+      } else if (node.dataset.workFocus === "next-ready") {
+        nodeClasses.push("nextReady");
+      }
+      if (node.dataset.cycle === "1") {
+        nodeClasses.push("cycle");
+      } else if (node.dataset.critical === "1") {
+        nodeClasses.push("chain");
+      }
+    }
+    element.setAttribute("class", nodeClasses.join(" "));
     nodeGroup.append(element);
   }
   fragment.append(nodeGroup);
@@ -2610,6 +2789,32 @@ function getGraphFitZoomForPane(pane: HTMLElement) {
   return normalizeGraphZoom(fitZoom);
 }
 
+function focusGraphWorkToPane(pane: HTMLElement, persist: boolean = true) {
+  const scroller = getGraphScroller(pane);
+  const focusBounds = getGraphRectBounds(getGraphWorkFocusNodes(pane).map(getGraphNodeRect));
+  if (scroller === null || focusBounds === null) {
+    return false;
+  }
+  const viewport = getGraphViewportSize(scroller);
+  const focused = computeGraphFitTransformForRect(viewport, focusBounds, GRAPH_FOCUS_PADDING);
+  const zoom = normalizeGraphZoom(focused.zoom);
+  const pan = clampGraphPanForPane(
+    pane,
+    zoom === focused.zoom ? focused.pan : computeGraphPanToCenterRect(viewport, focusBounds, zoom),
+    zoom
+  );
+  initializedGraphPanes.add(pane);
+  setGraphTransform(pane, { zoom, pan });
+  applyGraphZoomToPane(pane);
+  scroller.scrollLeft = 0;
+  scroller.scrollTop = 0;
+  saveGraphScroll(pane);
+  if (persist) {
+    saveGraphTransforms();
+  }
+  return true;
+}
+
 function fitGraphToPane(pane: HTMLElement, persist: boolean = true) {
   const nextZoom = getGraphFitZoomForPane(pane);
   const scroller = getGraphScroller(pane);
@@ -2656,7 +2861,9 @@ function updateGraphViewportPreservingTransform(
       continue;
     }
     if (!initializedGraphPanes.has(pane) && !hasPersistedGraphTransform(pane)) {
-      fitGraphToPane(pane, false);
+      if (!focusGraphWorkToPane(pane, false)) {
+        fitGraphToPane(pane, false);
+      }
     } else {
       const transform = getGraphTransform(pane);
       const scroller = getGraphScroller(pane);
@@ -3065,6 +3272,12 @@ function handleGraphKeydown(pane: HTMLElement, event: KeyboardEvent) {
   } else if (event.key === "-") {
     event.preventDefault();
     setGraphZoom(pane, getGraphTransform(pane).zoom / 1.2);
+  } else if (event.key.toLowerCase() === "f") {
+    event.preventDefault();
+    if (!focusGraphWorkToPane(pane)) {
+      fitGraphToPane(pane);
+    }
+    renderDependencyGraphOverlays();
   } else if (event.key === "0") {
     event.preventDefault();
     fitGraphToPane(pane);
@@ -3457,6 +3670,11 @@ function bindGraphPanes() {
           setGraphZoom(pane, getGraphTransform(pane).zoom * 1.2);
         } else if (action === "out") {
           setGraphZoom(pane, getGraphTransform(pane).zoom / 1.2);
+        } else if (action === "focus") {
+          if (!focusGraphWorkToPane(pane)) {
+            fitGraphToPane(pane);
+          }
+          renderDependencyGraphOverlays();
         } else if (action === "fit") {
           fitGraphToPane(pane);
           renderDependencyGraphOverlays();

--- a/web/graphViewportTransform.ts
+++ b/web/graphViewportTransform.ts
@@ -47,6 +47,17 @@ export function computeCenteredGraphPan(viewport: GraphSize, scaledContent: Grap
   };
 }
 
+export function computeGraphPanForStableAnchor(
+  currentPan: GraphPoint,
+  previousAnchor: GraphPoint,
+  nextAnchor: GraphPoint
+): GraphPoint {
+  return {
+    x: currentPan.x + previousAnchor.x - nextAnchor.x,
+    y: currentPan.y + previousAnchor.y - nextAnchor.y
+  };
+}
+
 export function computeGraphPanToCenterRect(
   viewport: GraphSize,
   rect: GraphRect,
@@ -55,6 +66,25 @@ export function computeGraphPanToCenterRect(
   return {
     x: viewport.width / 2 - (rect.x + rect.width / 2) * zoom,
     y: viewport.height / 2 - (rect.y + rect.height / 2) * zoom
+  };
+}
+
+export function computeGraphFitTransformForRect(
+  viewport: GraphSize,
+  rect: GraphRect,
+  padding: number,
+  maximumZoom: number = 1
+) {
+  const availableWidth = Math.max(1, viewport.width - padding * 2);
+  const availableHeight = Math.max(1, viewport.height - padding * 2);
+  const zoom = Math.min(
+    maximumZoom,
+    availableWidth / Math.max(1, rect.width),
+    availableHeight / Math.max(1, rect.height)
+  );
+  return {
+    zoom,
+    pan: computeGraphPanToCenterRect(viewport, rect, zoom)
   };
 }
 


### PR DESCRIPTION
## Summary

- Focus a new Graph viewport on recorded in-progress and bd-ready work.
- Keep task identity stable on screen when refresh changes layout order.

## Changes

- Classify Graph tasks as Now, Next ready, or other using existing project-state rules.
- Order Now and Next tasks first within each visible dependency stage.
- Add focused task styling, a reduced-motion-safe status pulse, Focus controls, and minimap markers.
- Preserve saved viewports and per-workspace semantic anchors during refresh.
- Add regression coverage and update user documentation.

## Testing

- pnpm run format
- pnpm run lint
- pnpm run typecheck
- pnpm test (403 passed, 1 skipped)
- pnpm audit --audit-level high
- pnpm run package
- git diff --check

## Notes

- Now means recorded in progress, not a live provider heartbeat.
- Automated browser and Extension Host interaction was not run. Browser control was unavailable in this environment, and Safari remote automation was disabled.
- The all-worktree sync guard still reports two unrelated stale worktrees that do not contain origin/main.