### PR TITLE
chore(release): prepare v0.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.6.3] - 2026-08-26
+
 ### Added
 
 - Focus a new Graph viewport on recorded in-progress and `bd ready` tasks while preserving saved
@@ -11,11 +13,21 @@
 - Let direct providers create or replace one declared workspace artifact through a bounded
   generation, verifier, and explicit human-review flow.
 - Add a dependency-linked Ollama smoke test for the nominal 0.5B `qwen2.5-coder:0.5b` model.
+- Add regression coverage for Graph visibility, action settlement, keyboard focus, provider state,
+  and cross-platform VS Code CLI launch paths.
 
 ### Fixed
 
 - Keep provider completion separate from acceptance, reject refusal, generic, copied, unsafe, or
   colliding outputs, and leave tasks in progress after an approved edit is applied.
+- Preserve view selection, scroll position, Graph transforms, workspace-scoped collapse state, and
+  pending actions across refreshes without flashing or moving controls.
+- Keep Graph filtering independent from Table collapse, reduce minimap repaint work, and keep task
+  details and dependency overlays readable.
+- Order Manage work by readiness and priority, attach pending state to the correct task, and settle
+  Retry, Start, Merge, Sync, Create, Refresh, and Plan actions through the Extension Host.
+- Hide raw Beads CLI output, show provider validation state clearly, and repair package-and-install
+  on macOS, Linux, and Windows without shell-based command execution.
 
 ## [0.6.2] - 2026-08-21
 
@@ -477,7 +489,9 @@
 
 Initial release
 
-[Unreleased]: https://github.com/ToppyMicroServices/beads-git-graph/compare/v0.6.0...HEAD
+[Unreleased]: https://github.com/ToppyMicroServices/beads-git-graph/compare/v0.6.3...HEAD
+[0.6.3]: https://github.com/ToppyMicroServices/beads-git-graph/compare/v0.6.2...v0.6.3
+[0.6.2]: https://github.com/ToppyMicroServices/beads-git-graph/compare/v0.6.0...v0.6.2
 [0.6.0]: https://github.com/ToppyMicroServices/beads-git-graph/compare/v0.4.20260710...v0.6.0
 [0.4.20260710]: https://github.com/ToppyMicroServices/beads-git-graph/compare/v0.4.20260709...v0.4.20260710
 [0.4.20260709]: https://github.com/ToppyMicroServices/beads-git-graph/compare/v0.4.20260708...v0.4.20260709

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Beads Git Graph
 
 [![MIT License](https://img.shields.io/badge/license-MIT-2ea44f?style=flat-square)](./LICENSE)
-[![Version 0.6.2](https://img.shields.io/badge/version-0.6.2-0366d6?style=flat-square)](./CHANGELOG.md)
+[![Version 0.6.3](https://img.shields.io/badge/version-0.6.3-0366d6?style=flat-square)](./CHANGELOG.md)
 
 A local-first project manager for coordinating dependency-linked work across different AI providers
 and requested models, with Git graph and Beads issue tools in one VS Code extension.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "beads-git-graph",
   "displayName": "Beads Git Graph",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Git graph and Beads issue tools for VS Code.",
   "categories": [
     "Other",

--- a/tests/installPackageScript.test.ts
+++ b/tests/installPackageScript.test.ts
@@ -66,7 +66,7 @@ describe("package installer", () => {
       repoRoot: "/repo",
       env: environment,
       platform: "win32",
-      readFileSync: () => JSON.stringify({ name: "beads-git-graph", version: "0.6.2" }),
+      readFileSync: () => JSON.stringify({ name: "beads-git-graph", version: "0.6.3" }),
       existsSync: () => true,
       spawnSync: spawn
     });
@@ -76,7 +76,7 @@ describe("package installer", () => {
     expect(cli).toBe(executable);
     expect(spawn).toHaveBeenCalledWith(
       executable,
-      [cliScript, "--install-extension", "/repo/beads-git-graph-0.6.2.vsix", "--force"],
+      [cliScript, "--install-extension", "/repo/beads-git-graph-0.6.3.vsix", "--force"],
       {
         cwd: "/repo",
         encoding: "utf8",
@@ -94,7 +94,7 @@ describe("package installer", () => {
       repoRoot: "/repo",
       env: {},
       platform: "darwin",
-      readFileSync: () => JSON.stringify({ name: "beads-git-graph", version: "0.6.2" }),
+      readFileSync: () => JSON.stringify({ name: "beads-git-graph", version: "0.6.3" }),
       existsSync: () => true,
       spawnSync: spawn
     });
@@ -102,7 +102,7 @@ describe("package installer", () => {
     expect(cli).toBe("/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code");
     expect(spawn).toHaveBeenLastCalledWith(
       "/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code",
-      ["--install-extension", "/repo/beads-git-graph-0.6.2.vsix", "--force"],
+      ["--install-extension", "/repo/beads-git-graph-0.6.3.vsix", "--force"],
       { cwd: "/repo", encoding: "utf8" }
     );
   });
@@ -111,7 +111,7 @@ describe("package installer", () => {
     expect(() =>
       installPackage({
         repoRoot: "/repo",
-        readFileSync: () => JSON.stringify({ name: "beads-git-graph", version: "0.6.2" }),
+        readFileSync: () => JSON.stringify({ name: "beads-git-graph", version: "0.6.3" }),
         existsSync: () => false,
         spawnSync: vi.fn()
       })


### PR DESCRIPTION
## Summary

- Prepare the next stable Marketplace release from the UX and agent workflow changes already on main.

## Changes

- Bump the extension and README badge to 0.6.3.
- Move the shipped changes into the 0.6.3 changelog section.
- Update installer fixtures and changelog comparison links.

## Testing

- `pnpm run format`
- `pnpm run lint`
- `pnpm run typecheck`
- `env -u BEADS_AGENT_LIVE_OLLAMA_MODEL pnpm test` (429 passed, 1 skipped)
- `pnpm run audit`
- `pnpm run package`
- `unzip -t beads-git-graph-0.6.3.vsix`
- Isolated VS Code Extension Host smoke using the packaged VSIX

## Notes

- The skipped test is the opt-in live Ollama smoke test.