### PR TITLE
feat(agent-plugin): add Beads project manager plugin

### DIFF
--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -1,0 +1,18 @@
+{
+  "name": "toppymicroservices-agent-plugins",
+  "owner": {
+    "name": "ToppyMicroServices"
+  },
+  "metadata": {
+    "description": "Local-first agent project management plugins from ToppyMicroServices.",
+    "version": "0.1.0"
+  },
+  "plugins": [
+    {
+      "name": "beads-agent-project-manager",
+      "description": "Plan dependency-linked work, dispatch ready tasks, and track verified progress with Beads.",
+      "version": "0.1.0",
+      "source": "./agent-plugin"
+    }
+  ]
+}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   deploy:
-    if: ${{ github.event_name != 'release' || !startsWith(github.event.release.tag_name, 'daily-') }}
+    if: ${{ github.event_name != 'release' || (!startsWith(github.event.release.tag_name, 'daily-') && !startsWith(github.event.release.tag_name, 'agent-plugin-')) }}
     runs-on: ubuntu-latest
     env:
       OPEN_VSX_TOKEN: ${{ secrets.OPEN_VSX_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Added
+
+- Add a separate Agent Plugins 1.0 package with a Beads project-manager skill, Copilot custom
+  agent, and self-hosted plugin marketplace metadata.
+
 ## [0.6.3] - 2026-08-26
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -42,6 +42,24 @@ before approving an import or starting work.
 If your workspace has a `.beads` directory, the extension detects it automatically. Set the
 machine-scoped `beads-git-graph.bdPath` setting if `bd` is not on `PATH`.
 
+## Use as an Agent Plugin
+
+The repository also ships `beads-agent-project-manager`, an Agent Plugins 1.0 package for GitHub
+Copilot in VS Code and compatible clients. It adds a Beads-aware project-manager skill and a
+dedicated Copilot agent. The plugin is separate from the VSIX and uses the locally installed `bd`
+CLI; it does not expose the extension host as an MCP server.
+
+In VS Code, add this repository as a plugin marketplace:
+
+```json
+{ "chat.plugins.marketplaces": ["ToppyMicroServices/beads-git-graph"] }
+```
+
+Then search Extensions for `@agentPlugins` and install **Beads Agent Project Manager**. See the
+[Agent plugin installation and safety notes](./docs/agent-plugin.md). The plugin is isolated under
+`agent-plugin/`; installing it does not package the repository's Beads database, VSIX files, or
+development dependencies.
+
 ## Manage Agent Work
 
 Open **Manage** in the Beads view to see the Agent Work Queue. It derives each lane from Beads status and recorded worktree, PR, check, and sync-risk metadata:

--- a/agent-plugin/README.md
+++ b/agent-plugin/README.md
@@ -1,0 +1,20 @@
+# Beads Agent Project Manager
+
+Plan dependency-linked work, dispatch ready tasks across agents, and track verified progress with
+Beads.
+
+The plugin provides:
+
+- the portable `beads-project-manager` skill;
+- a **Beads Project Manager** custom agent for GitHub Copilot clients.
+
+It uses the `bd` executable installed in the active environment. It does not bundle Beads, install
+software, initialize a project, or expose the Beads Git Graph VSIX as an MCP server.
+
+The workflow reads repository instructions first, feature-detects the installed Beads command
+surface, and uses read-only queries before proposing mutations. It never automatically runs
+`bd migrate`, `bd bootstrap`, or `--ignore-schema-skew`. Agent output is not treated as accepted
+work until the actual artifact and its acceptance checks have been verified.
+
+See the repository's [installation and safety notes](https://github.com/ToppyMicroServices/beads-git-graph/blob/main/docs/agent-plugin.md)
+before installing.

--- a/agent-plugin/com.github.copilot/agents/beads-project-manager.agent.md
+++ b/agent-plugin/com.github.copilot/agents/beads-project-manager.agent.md
@@ -1,0 +1,12 @@
+---
+name: Beads Project Manager
+description: Plan and coordinate dependency-linked work across agents with Beads as the local source of truth.
+---
+
+Act as a local project manager for agent work. Use the `beads-project-manager` skill whenever the
+request involves planning, dependency mapping, task assignment, readiness, progress, or acceptance.
+
+Keep planning separate from execution. Show dependency direction and parallel waves before writing
+tasks. Treat Beads status as recorded state, validate readiness with the installed `bd` CLI, and
+verify actual artifacts before closing work. Never migrate or bootstrap an existing Beads database
+without an explicit operator decision.

--- a/agent-plugin/plugin.json
+++ b/agent-plugin/plugin.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+  "name": "beads-agent-project-manager",
+  "description": "Plan dependency-linked work, dispatch ready tasks, and track verified progress with Beads.",
+  "version": "0.1.0",
+  "author": {
+    "name": "ToppyMicroServices",
+    "url": "https://github.com/ToppyMicroServices"
+  },
+  "homepage": "https://github.com/ToppyMicroServices/beads-git-graph#use-as-an-agent-plugin",
+  "repository": "https://github.com/ToppyMicroServices/beads-git-graph",
+  "license": "MIT",
+  "keywords": ["agents", "beads", "dependencies", "multi-agent", "project-management"],
+  "extensions": {
+    "com.github.copilot": {}
+  }
+}

--- a/agent-plugin/skills/beads-project-manager/SKILL.md
+++ b/agent-plugin/skills/beads-project-manager/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: beads-project-manager
+description: Plan, decompose, assign, and track dependency-linked agent work with the bd CLI. Use when a user asks to create a Beads plan, coordinate parallel agents, select ready work, or report verified progress.
+---
+
+# Beads project manager
+
+Use Beads as the local source of truth for task identity, status, dependencies, acceptance criteria,
+and handoffs. Treat Git branches, worktrees, pull requests, tests, and produced files as evidence;
+do not infer completion from an agent response alone.
+
+## Establish the local contract
+
+1. Read repository instructions such as `AGENTS.md`, `CONTRIBUTING.md`, and relevant nested files.
+2. Inspect `git status --short --branch` before proposing mutations.
+3. Check `bd --version` and the help for each command before relying on an option. Beads command
+   surfaces vary by version. Do not assume that `bd sync` exists.
+4. If `.beads` exists, begin with read-only queries such as `bd --readonly status --json`,
+   `bd --readonly ready --json`, and `bd --readonly list --json` when supported.
+5. If `bd` is unavailable, produce a reviewable task plan and report the missing prerequisite. Do
+   not install software without the user's approval.
+6. If `.beads` is absent, keep planning read-only. Before initialization, show the exact command
+   and warn that some Beads versions can modify or commit `.beads` and `.gitignore`. Initialize only
+   after explicit approval and only with options confirmed by `bd init --help`.
+
+Never automatically run `bd migrate`, `bd bootstrap`, or `--ignore-schema-skew`. A remote-backed
+schema mismatch needs an operator decision about the single designated migrator or adoption of an
+already-migrated remote. Preserve the error and explain the choices without printing raw errors into
+task titles, descriptions, or other user content.
+
+## Build a reviewable plan
+
+Decompose the goal until each leaf task has:
+
+- one concrete outcome and observable acceptance criteria;
+- a small, explicit edit or investigation scope;
+- the files, references, or upstream task artifacts it may read;
+- dependency edges only where downstream work truly needs upstream output;
+- a proposed owner/provider/model only when the user requested allocation.
+
+Prefer independent leaf tasks that can run in parallel. Keep integration, acceptance testing, and
+release decisions as separate downstream tasks. Do not create a grid of unrelated tasks merely to
+increase parallelism.
+
+Before writing to Beads, show:
+
+1. the tasks and acceptance criteria;
+2. dependency direction in plain language (`B depends on A`);
+3. the tasks ready at the start and the later parallel waves;
+4. the exact `bd` mutations or a supported `bd create --graph` input.
+
+Use `bd create --dry-run` when the installed version supports it. Ask for approval before creating
+or rewiring tasks unless the user already explicitly requested those writes.
+
+## Dispatch ready work
+
+Use `bd ready --json` as the readiness authority when it is supported. Do not dispatch an open task
+merely because it looks unblocked in a manually reconstructed graph. Claim a selected task
+atomically with `bd update <id> --claim` when supported.
+
+For parallel work:
+
+- give each agent one leaf task with its Beads ID, acceptance criteria, allowed scope, and required
+  upstream artifacts;
+- use separate worktrees or otherwise isolated edit scopes when agents can change overlapping
+  repositories;
+- record branch, worktree, provider/model request, and output path as metadata only when the local
+  Beads version supports the chosen fields;
+- keep integration serialized after all required upstream evidence exists.
+
+An assigned task is not necessarily running. An `in_progress` status is recorded state, not a live
+heartbeat. Say which evidence is observed and which state is only recorded.
+
+## Verify and update progress
+
+For every result:
+
+1. inspect the actual diff or artifact;
+2. run the acceptance checks appropriate to the task;
+3. record the exact checks and their outcomes;
+4. update or close the Beads task only after its acceptance criteria are satisfied;
+5. unblock downstream work by re-running `bd ready --json` rather than guessing.
+
+`response_completed`, generated text, a pushed branch, or an open pull request does not by itself
+mean that the task was accepted. If verification is unavailable, leave the task open and record the
+missing evidence.
+
+End with a short status report containing completed task IDs, currently ready task IDs, blocked
+task IDs with reasons, observed test results, and the next operator decision. Never claim a push,
+publication, deployment, migration, or user review that did not occur.

--- a/docs/agent-plugin.md
+++ b/docs/agent-plugin.md
@@ -1,0 +1,55 @@
+# Beads Agent Project Manager plugin
+
+This repository also contains an Agent Plugins 1.0 package for GitHub Copilot in VS Code and
+compatible clients. It is separate from the Beads Git Graph VSIX:
+
+- the VSIX provides the Graph, Table, Manage, and Plan user interface;
+- the agent plugin provides a Beads-aware project-manager skill and a Copilot custom agent;
+- the plugin uses the installed `bd` CLI and does not call the VSIX Extension Host API.
+
+The publishable plugin is isolated under `agent-plugin/`. Marketplace installation therefore does
+not copy the repository's `.beads` database, VSIX files, `node_modules`, or development sources
+into the Agent Plugin cache.
+
+## Install from the repository marketplace
+
+1. Enable `chat.plugins.enabled` in VS Code.
+2. Add this repository to `chat.plugins.marketplaces`:
+
+```json
+{
+  "chat.plugins.marketplaces": ["ToppyMicroServices/beads-git-graph"]
+}
+```
+
+3. Open the Agent Plugins view or search Extensions for `@agentPlugins`.
+4. Install **Beads Agent Project Manager**, review the repository trust prompt, and confirm the
+   installed skill and agent in **Chat: Open Customizations**.
+
+The marketplace is defined by `.github/plugin/marketplace.json` and points only to
+`agent-plugin/`. Review changes before updating because plugins can instruct an agent to run local
+tools.
+
+With GitHub Copilot CLI:
+
+```sh
+copilot plugin marketplace add ToppyMicroServices/beads-git-graph
+copilot plugin install beads-agent-project-manager@toppymicroservices-agent-plugins
+```
+
+For local development, Copilot CLI also accepts the repository subdirectory explicitly:
+
+```sh
+copilot plugin install ToppyMicroServices/beads-git-graph:agent-plugin
+```
+
+This self-hosted marketplace is public when these files are present on the repository's default
+branch. Inclusion in a marketplace that VS Code configures by default is a separate review and
+submission process.
+
+## Safety boundary
+
+The plugin does not bundle Beads, install software, initialize a project, or expose an MCP server.
+It asks the agent to feature-detect the local `bd` command surface, use read-only queries first, and
+verify artifacts before closing tasks. It must not automatically run `bd migrate`, `bd bootstrap`,
+or `--ignore-schema-skew`.

--- a/tests/agentPluginMetadata.test.ts
+++ b/tests/agentPluginMetadata.test.ts
@@ -1,0 +1,72 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const repoRoot = join(import.meta.dirname, "..");
+const pluginRoot = join(repoRoot, "agent-plugin");
+const plugin = JSON.parse(readFileSync(join(pluginRoot, "plugin.json"), "utf8")) as {
+  $schema: string;
+  name: string;
+  version: string;
+  description: string;
+  extensions?: Record<string, unknown>;
+};
+const marketplace = JSON.parse(
+  readFileSync(join(repoRoot, ".github", "plugin", "marketplace.json"), "utf8")
+) as {
+  name: string;
+  metadata: { version: string };
+  plugins: Array<{ name: string; version: string; source: string; description: string }>;
+};
+const skill = readFileSync(join(pluginRoot, "skills", "beads-project-manager", "SKILL.md"), "utf8");
+const agent = readFileSync(
+  join(pluginRoot, "com.github.copilot", "agents", "beads-project-manager.agent.md"),
+  "utf8"
+);
+const docs = readFileSync(join(repoRoot, "docs", "agent-plugin.md"), "utf8");
+
+describe("agent plugin metadata", () => {
+  it("declares an Agent Plugins 1.0 manifest", () => {
+    expect(plugin.$schema).toBe("https://agent-plugins.org/schemas/1.0.0/plugin.schema.json");
+    expect(plugin.name).toMatch(/^[a-z0-9][a-z0-9.-]*$/);
+    expect(plugin.version).toMatch(/^\d+\.\d+\.\d+$/);
+    expect(plugin.description.length).toBeGreaterThan(20);
+    expect(plugin.extensions).toHaveProperty("com.github.copilot");
+  });
+
+  it("publishes the isolated plugin through the repository marketplace", () => {
+    expect(marketplace.name).toBe("toppymicroservices-agent-plugins");
+    expect(marketplace.metadata.version).toBe(plugin.version);
+    expect(marketplace.plugins).toEqual([
+      expect.objectContaining({
+        name: plugin.name,
+        version: plugin.version,
+        source: "./agent-plugin",
+        description: plugin.description
+      })
+    ]);
+  });
+
+  it("provides a discoverable skill and Copilot custom agent", () => {
+    expect(skill).toMatch(/^---\nname: beads-project-manager\ndescription: .+\n---\n/);
+    expect(agent).toMatch(/^---\nname: Beads Project Manager\ndescription: .+\n---\n/);
+    expect(agent).toContain("`beads-project-manager` skill");
+  });
+
+  it("keeps dangerous Beads recovery actions operator-gated", () => {
+    expect(skill).toContain(
+      "Never automatically run `bd migrate`, `bd bootstrap`, or `--ignore-schema-skew`"
+    );
+    expect(skill).toContain("does not by itself\nmean that the task was accepted");
+    expect(skill).toContain("Ask for approval before creating\nor rewiring tasks");
+  });
+
+  it("documents direct and marketplace installation without conflating the VSIX", () => {
+    expect(docs).toContain('"chat.plugins.marketplaces"');
+    expect(docs).toContain("copilot plugin marketplace add ToppyMicroServices/beads-git-graph");
+    expect(docs).toContain("ToppyMicroServices/beads-git-graph:agent-plugin");
+    expect(docs).toContain("It is separate from the Beads Git Graph VSIX");
+    expect(docs).toContain("a separate review and\nsubmission process");
+  });
+});

--- a/tests/releaseMetadata.test.ts
+++ b/tests/releaseMetadata.test.ts
@@ -19,6 +19,9 @@ describe("release metadata", () => {
   it("publishes without the deprecated HaaLeo action", () => {
     expect(publishWorkflow).not.toContain("HaaLeo/publish-vscode-extension");
     expect(publishWorkflow).toContain("!startsWith(github.event.release.tag_name, 'daily-')");
+    expect(publishWorkflow).toContain(
+      "!startsWith(github.event.release.tag_name, 'agent-plugin-')"
+    );
     expect(publishWorkflow).toContain('pnpm exec ovsx -p "$OPEN_VSX_TOKEN" publish -i');
     expect(publishWorkflow).toContain("pnpm exec vsce publish --packagePath");
     expect(publishWorkflow).not.toContain("pnpm dlx");


### PR DESCRIPTION
## Summary

- Add a separate Agent Plugins 1.0 package for Beads-based project management.
- Publish it through a repository-hosted plugin marketplace.

## Changes

- Add a portable Beads project-manager skill and Copilot custom agent.
- Keep the plugin isolated under `agent-plugin/` so repository databases, VSIX files, and development dependencies are not installed with it.
- Add marketplace metadata, installation documentation, and regression tests.
- Preserve operator gates for Beads initialization, migration, bootstrap, and acceptance decisions.

## Testing

- `pnpm run format`
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm test` (434 passed, 1 skipped)
- `pnpm run package`
- `pnpm audit --audit-level high`
- Copilot CLI 1.0.82 local plugin install smoke in an isolated HOME
- Copilot CLI 1.0.82 marketplace add and plugin install smoke in an isolated HOME
- VSIX content check confirmed Agent Plugin files are not included

## Notes

- The plugin requires an existing `bd` executable. It does not bundle or install Beads.
- Submission to a default VS Code Agent Plugin marketplace is a separate review after merge and immutable tagging.
- The local Beads database remains blocked by the existing remote-backed v49 to v53 migration gate; no migration or bootstrap was run.