### PR TITLE
fix(agent-plugin): harden release and install boundaries

### DIFF
--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Local-first agent project management plugins from ToppyMicroServices.",
-    "version": "0.1.0"
+    "version": "0.1.1"
   },
   "plugins": [
     {
       "name": "beads-agent-project-manager",
-      "description": "Plan dependency-linked work, dispatch ready tasks, and track verified progress with Beads.",
-      "version": "0.1.0",
+      "description": "Plan dependency-linked work, coordinate ready tasks, and track verified progress with Beads.",
+      "version": "0.1.1",
       "source": "./agent-plugin"
     }
   ]

--- a/.github/workflows/agent-plugin-release.yml
+++ b/.github/workflows/agent-plugin-release.yml
@@ -1,0 +1,34 @@
+name: Agent Plugin release check
+
+on:
+  push:
+    tags:
+      - agent-plugin-v*
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing Agent Plugin tag to validate
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.repository.default_branch }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: 22
+
+      - name: Validate tag and manifests
+        env:
+          AGENT_PLUGIN_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+        run: node ./scripts/check-agent-plugin-release.mjs --tag "$AGENT_PLUGIN_TAG"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,6 +43,9 @@ jobs:
       - name: Check PR head contains latest base
         run: node ./scripts/worktree-sync-guard.mjs --base "origin/${{ github.base_ref }}"
 
+      - name: Check Agent Plugin version bump
+        run: node ./scripts/check-agent-plugin-release.mjs --base "origin/${{ github.base_ref }}"
+
   lint:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,15 @@ on:
 
 jobs:
   deploy:
-    if: ${{ github.event_name != 'release' || (!startsWith(github.event.release.tag_name, 'daily-') && !startsWith(github.event.release.tag_name, 'agent-plugin-')) }}
+    if: >-
+      ${{
+        (github.event_name == 'release' &&
+          !startsWith(github.event.release.tag_name, 'daily-') &&
+          !startsWith(github.event.release.tag_name, 'agent-plugin-')) ||
+        (github.event_name == 'workflow_dispatch' &&
+          !startsWith(github.ref_name, 'daily-') &&
+          !startsWith(github.ref_name, 'agent-plugin-'))
+      }}
     runs-on: ubuntu-latest
     env:
       OPEN_VSX_TOKEN: ${{ secrets.OPEN_VSX_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,6 @@
 
 ## [Unreleased]
 
-### Added
-
-- Add a separate Agent Plugins 1.0 package with a Beads project-manager skill, Copilot custom
-  agent, and self-hosted plugin marketplace metadata.
-
 ## [0.6.3] - 2026-08-26
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -52,13 +52,17 @@ CLI; it does not expose the extension host as an MCP server.
 In VS Code, add this repository as a plugin marketplace:
 
 ```json
-{ "chat.plugins.marketplaces": ["ToppyMicroServices/beads-git-graph"] }
+{
+  "chat.plugins.enabled": true,
+  "chat.plugins.marketplaces": ["ToppyMicroServices/beads-git-graph"]
+}
 ```
 
 Then search Extensions for `@agentPlugins` and install **Beads Agent Project Manager**. See the
-[Agent plugin installation and safety notes](./docs/agent-plugin.md). The plugin is isolated under
-`agent-plugin/`; installing it does not package the repository's Beads database, VSIX files, or
-development dependencies.
+[Agent plugin installation and safety notes](./docs/agent-plugin.md). The active plugin payload is
+sourced from `agent-plugin/` and excludes the repository's Beads database, VSIX files,
+`node_modules`, and extension sources. A self-hosted marketplace client may still clone the full
+public repository into its marketplace source cache.
 
 ## Manage Agent Work
 

--- a/agent-plugin/CHANGELOG.md
+++ b/agent-plugin/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+## [0.1.1] - 2026-08-30
+
+### Fixed
+
+- Explain the difference between the active plugin payload and the full-repository marketplace
+  source cache.
+- Include the required VS Code plugin enablement setting and recommend the supported marketplace
+  install path.
+- Clarify that starting parallel agents depends on tools provided by the host client.
+
+## [0.1.0] - 2026-08-30
+
+### Added
+
+- Add a Beads project-manager skill and GitHub Copilot custom agent.
+- Publish self-hosted marketplace metadata for VS Code and GitHub Copilot CLI.

--- a/agent-plugin/README.md
+++ b/agent-plugin/README.md
@@ -1,6 +1,6 @@
 # Beads Agent Project Manager
 
-Plan dependency-linked work, dispatch ready tasks across agents, and track verified progress with
+Plan dependency-linked work, coordinate ready tasks across agents, and track verified progress with
 Beads.
 
 The plugin provides:
@@ -11,10 +11,26 @@ The plugin provides:
 It uses the `bd` executable installed in the active environment. It does not bundle Beads, install
 software, initialize a project, or expose the Beads Git Graph VSIX as an MCP server.
 
-The workflow reads repository instructions first, feature-detects the installed Beads command
-surface, and uses read-only queries before proposing mutations. It never automatically runs
-`bd migrate`, `bd bootstrap`, or `--ignore-schema-skew`. Agent output is not treated as accepted
-work until the actual artifact and its acceptance checks have been verified.
+## Start safely
+
+1. Confirm that Beads is already available with `bd --version`.
+2. Select **Beads Project Manager** in Chat.
+3. Start with a read-only prompt:
+
+```text
+Inspect this repository read-only. Show the ready tasks, dependency waves, and proposed owners.
+Do not mutate Beads or start agents.
+```
+
+Starting parallel agents requires compatible agent or task tools from the host client. When those
+tools are unavailable, the plugin produces a reviewable allocation plan instead of claiming that
+workers were started.
+
+The skill instructs the agent to read repository instructions first, feature-detect the installed
+Beads command surface, and use read-only queries before proposing mutations. It also instructs the
+agent never to automatically run `bd migrate`, `bd bootstrap`, or `--ignore-schema-skew`. Agent
+output is not treated as accepted work until the actual artifact and its acceptance checks have
+been verified.
 
 See the repository's [installation and safety notes](https://github.com/ToppyMicroServices/beads-git-graph/blob/main/docs/agent-plugin.md)
-before installing.
+before installing. Release history is recorded in [CHANGELOG.md](./CHANGELOG.md).

--- a/agent-plugin/plugin.json
+++ b/agent-plugin/plugin.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "beads-agent-project-manager",
-  "description": "Plan dependency-linked work, dispatch ready tasks, and track verified progress with Beads.",
-  "version": "0.1.0",
+  "description": "Plan dependency-linked work, coordinate ready tasks, and track verified progress with Beads.",
+  "version": "0.1.1",
   "author": {
     "name": "ToppyMicroServices",
     "url": "https://github.com/ToppyMicroServices"

--- a/agent-plugin/skills/beads-project-manager/SKILL.md
+++ b/agent-plugin/skills/beads-project-manager/SKILL.md
@@ -58,6 +58,9 @@ Use `bd ready --json` as the readiness authority when it is supported. Do not di
 merely because it looks unblocked in a manually reconstructed graph. Claim a selected task
 atomically with `bd update <id> --claim` when supported.
 
+Start other agents only when the host client exposes compatible agent or task tools. Otherwise,
+produce the assignments and handoff prompts for review, and do not claim that workers are running.
+
 For parallel work:
 
 - give each agent one leaf task with its Beads ID, acceptance criteria, allowed scope, and required

--- a/docs/agent-plugin.md
+++ b/docs/agent-plugin.md
@@ -7,9 +7,10 @@ compatible clients. It is separate from the Beads Git Graph VSIX:
 - the agent plugin provides a Beads-aware project-manager skill and a Copilot custom agent;
 - the plugin uses the installed `bd` CLI and does not call the VSIX Extension Host API.
 
-The publishable plugin is isolated under `agent-plugin/`. Marketplace installation therefore does
-not copy the repository's `.beads` database, VSIX files, `node_modules`, or development sources
-into the Agent Plugin cache.
+The active plugin payload is sourced only from `agent-plugin/`. It excludes the repository's
+`.beads` database, VSIX files, `node_modules`, and extension sources. Self-hosted marketplace
+clients can clone the full public repository into a separate marketplace source cache, so that
+source cache can contain tracked files outside the active plugin payload.
 
 ## Install from the repository marketplace
 
@@ -18,30 +19,45 @@ into the Agent Plugin cache.
 
 ```json
 {
+  "chat.plugins.enabled": true,
   "chat.plugins.marketplaces": ["ToppyMicroServices/beads-git-graph"]
 }
 ```
 
 3. Open the Agent Plugins view or search Extensions for `@agentPlugins`.
-4. Install **Beads Agent Project Manager**, review the repository trust prompt, and confirm the
+4. Install **Beads Agent Project Manager**, review the marketplace trust prompt, and confirm the
    installed skill and agent in **Chat: Open Customizations**.
 
 The marketplace is defined by `.github/plugin/marketplace.json` and points only to
 `agent-plugin/`. Review changes before updating because plugins can instruct an agent to run local
 tools.
 
-With GitHub Copilot CLI:
+With GitHub Copilot CLI, use the marketplace form:
 
 ```sh
 copilot plugin marketplace add ToppyMicroServices/beads-git-graph
 copilot plugin install beads-agent-project-manager@toppymicroservices-agent-plugins
 ```
 
-For local development, Copilot CLI also accepts the repository subdirectory explicitly:
+Copilot CLI 1.0.82 still accepts the direct repository form
+`ToppyMicroServices/beads-git-graph:agent-plugin` and lists it in `plugin install --help`, but the
+runtime emits a deprecation warning for direct installs. Use the marketplace form above as the
+recommended forward-compatible path.
 
-```sh
-copilot plugin install ToppyMicroServices/beads-git-graph:agent-plugin
+## Start safely
+
+1. Confirm that Beads is already available with `bd --version`.
+2. Select **Beads Project Manager** in Chat.
+3. Start with a read-only request such as:
+
+```text
+Inspect this repository read-only. Show the ready tasks, dependency waves, and proposed owners.
+Do not mutate Beads or start agents.
 ```
+
+The plugin can coordinate assignments and readiness with the local `bd` CLI. Starting parallel
+agents requires a client that exposes compatible agent or task tools. Without those tools, it
+returns a reviewable allocation plan instead of claiming that workers were started.
 
 This self-hosted marketplace is public when these files are present on the repository's default
 branch. Inclusion in a marketplace that VS Code configures by default is a separate review and

--- a/scripts/check-agent-plugin-release.mjs
+++ b/scripts/check-agent-plugin-release.mjs
@@ -1,0 +1,255 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptPath = fileURLToPath(import.meta.url);
+const repoRoot = resolve(dirname(scriptPath), "..");
+const pluginManifestPath = "agent-plugin/plugin.json";
+const marketplacePath = ".github/plugin/marketplace.json";
+
+export const PLUGIN_NAME_PATTERN = /^(?!.*(?:--|\.\.))[a-z0-9](?:[a-z0-9.-]*[a-z0-9])?$/;
+
+const pluginKeys = new Set([
+  "$schema",
+  "name",
+  "version",
+  "description",
+  "author",
+  "homepage",
+  "repository",
+  "license",
+  "keywords",
+  "extensions"
+]);
+const authorKeys = new Set(["name", "email", "url"]);
+
+function isJsonObject(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function assertOnlyKeys(value, allowedKeys, label) {
+  const unexpected = Object.keys(value).filter((key) => !allowedKeys.has(key));
+  if (unexpected.length > 0) {
+    throw new Error(`${label} contains unsupported field(s): ${unexpected.join(", ")}`);
+  }
+}
+
+function assertOptionalString(value, field) {
+  if (value !== undefined && typeof value !== "string") {
+    throw new Error(`plugin.json ${field} must be a string`);
+  }
+}
+
+export function parseSemver(value) {
+  const match = /^(\d+)\.(\d+)\.(\d+)$/.exec(value);
+  if (!match) {
+    throw new Error(`Invalid semantic version: ${value}`);
+  }
+  return match.slice(1).map(Number);
+}
+
+export function compareSemver(left, right) {
+  const leftParts = parseSemver(left);
+  const rightParts = parseSemver(right);
+  for (let index = 0; index < leftParts.length; index += 1) {
+    if (leftParts[index] !== rightParts[index]) {
+      return leftParts[index] > rightParts[index] ? 1 : -1;
+    }
+  }
+  return 0;
+}
+
+export function changesPluginRelease(changedPaths) {
+  return changedPaths.some(
+    (path) =>
+      path === marketplacePath || path === "agent-plugin" || path.startsWith("agent-plugin/")
+  );
+}
+
+export function validatePluginMetadata(plugin, marketplace) {
+  if (!isJsonObject(plugin)) {
+    throw new Error("plugin.json must contain a JSON object");
+  }
+  assertOnlyKeys(plugin, pluginKeys, "plugin.json");
+  if (plugin.$schema !== "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json") {
+    throw new Error("plugin.json does not use the Agent Plugins 1.0 schema");
+  }
+  if (
+    typeof plugin.name !== "string" ||
+    plugin.name.length > 64 ||
+    !PLUGIN_NAME_PATTERN.test(plugin.name)
+  ) {
+    throw new Error(`Invalid plugin name: ${plugin.name}`);
+  }
+  if (typeof plugin.version !== "string") {
+    throw new Error("plugin.json version must be a string");
+  }
+  parseSemver(plugin.version);
+  if (typeof plugin.description !== "string") {
+    throw new Error("plugin.json description must be a string");
+  }
+  for (const field of ["homepage", "repository", "license"]) {
+    assertOptionalString(plugin[field], field);
+  }
+  if (plugin.author !== undefined) {
+    if (!isJsonObject(plugin.author)) {
+      throw new Error("plugin.json author must be a JSON object");
+    }
+    assertOnlyKeys(plugin.author, authorKeys, "plugin.json author");
+    if (Object.values(plugin.author).some((value) => typeof value !== "string")) {
+      throw new Error("plugin.json author fields must be strings");
+    }
+  }
+  if (
+    plugin.keywords !== undefined &&
+    (!Array.isArray(plugin.keywords) ||
+      plugin.keywords.some((keyword) => typeof keyword !== "string"))
+  ) {
+    throw new Error("plugin.json keywords must be an array of strings");
+  }
+  if (!isJsonObject(plugin.extensions)) {
+    throw new Error("plugin.json extensions must be a JSON object");
+  }
+  for (const [namespace, value] of Object.entries(plugin.extensions)) {
+    if (!isJsonObject(value)) {
+      throw new Error(`plugin.json extension ${namespace} must be a JSON object`);
+    }
+  }
+  if (!Object.hasOwn(plugin.extensions, "com.github.copilot")) {
+    throw new Error("plugin.json must declare the com.github.copilot extension namespace");
+  }
+  if (!isJsonObject(marketplace) || !isJsonObject(marketplace.metadata)) {
+    throw new Error("marketplace.json and metadata must contain JSON objects");
+  }
+  if (!Array.isArray(marketplace.plugins) || marketplace.plugins.length !== 1) {
+    throw new Error("marketplace.json must publish exactly one plugin");
+  }
+
+  const entry = marketplace.plugins[0];
+  if (!isJsonObject(entry)) {
+    throw new Error("marketplace plugin entry must contain a JSON object");
+  }
+  const versions = [marketplace.metadata?.version, entry.version];
+  if (versions.some((version) => version !== plugin.version)) {
+    throw new Error("plugin and marketplace versions do not match");
+  }
+  if (entry.name !== plugin.name) {
+    throw new Error("plugin and marketplace names do not match");
+  }
+  if (entry.description !== plugin.description) {
+    throw new Error("plugin and marketplace descriptions do not match");
+  }
+  if (entry.source !== "./agent-plugin") {
+    throw new Error("marketplace source must remain ./agent-plugin");
+  }
+}
+
+function readJson(path) {
+  return JSON.parse(readFileSync(join(repoRoot, path), "utf8"));
+}
+
+function readJsonAtRef(ref, path) {
+  try {
+    execFileSync("git", ["cat-file", "-e", `${ref}:${path}`], {
+      cwd: repoRoot,
+      stdio: "ignore"
+    });
+  } catch {
+    return null;
+  }
+  return JSON.parse(
+    execFileSync("git", ["show", `${ref}:${path}`], {
+      cwd: repoRoot,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"]
+    })
+  );
+}
+
+function gitOutput(args) {
+  return execFileSync("git", args, {
+    cwd: repoRoot,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"]
+  }).trim();
+}
+
+export function parseArguments(args) {
+  if (args.length === 0) {
+    return { base: null, tag: null };
+  }
+  if (args.length !== 2) {
+    throw new Error("Usage: check-agent-plugin-release.mjs [--base <ref> | --tag <tag>]");
+  }
+  const [name, value] = args;
+  if ((name !== "--base" && name !== "--tag") || !value || value.startsWith("--")) {
+    throw new Error("Usage: check-agent-plugin-release.mjs [--base <ref> | --tag <tag>]");
+  }
+  return name === "--base" ? { base: value, tag: null } : { base: null, tag: value };
+}
+
+export function checkVersionBump(currentVersion, baseVersion, changedPaths) {
+  if (!changesPluginRelease(changedPaths) || baseVersion === null) {
+    return;
+  }
+  if (compareSemver(currentVersion, baseVersion) <= 0) {
+    throw new Error(
+      `Agent Plugin files changed without a version increase (base ${baseVersion}, current ${currentVersion})`
+    );
+  }
+}
+
+export function checkTagVersion(tag, version) {
+  const match = /^agent-plugin-v(\d+\.\d+\.\d+)$/.exec(tag);
+  if (!match) {
+    throw new Error(`Invalid Agent Plugin tag: ${tag}`);
+  }
+  if (match[1] !== version) {
+    throw new Error(`Tag ${tag} does not match plugin version ${version}`);
+  }
+}
+
+export function main(args = process.argv.slice(2)) {
+  const { base, tag } = parseArguments(args);
+  if (tag) {
+    const tagRef = `refs/tags/${tag}`;
+    const tagPlugin = readJsonAtRef(tagRef, pluginManifestPath);
+    const tagMarketplace = readJsonAtRef(tagRef, marketplacePath);
+    if (!tagPlugin || !tagMarketplace) {
+      throw new Error(`Tag ${tag} does not contain the Agent Plugin manifests`);
+    }
+    validatePluginMetadata(tagPlugin, tagMarketplace);
+    checkTagVersion(tag, tagPlugin.version);
+    console.log(`Agent Plugin tag ${tag} matches version ${tagPlugin.version}.`);
+    return;
+  }
+
+  const plugin = readJson(pluginManifestPath);
+  const marketplace = readJson(marketplacePath);
+  validatePluginMetadata(plugin, marketplace);
+
+  if (base) {
+    const changedPaths = gitOutput(["diff", "--name-only", `${base}...HEAD`])
+      .split("\n")
+      .filter(Boolean);
+    const basePlugin = readJsonAtRef(base, pluginManifestPath);
+    checkVersionBump(plugin.version, basePlugin?.version ?? null, changedPaths);
+    console.log(`Agent Plugin metadata and version bump are valid against ${base}.`);
+    return;
+  }
+
+  console.log(`Agent Plugin metadata is valid for version ${plugin.version}.`);
+}
+
+if (resolve(process.argv[1] ?? "") === scriptPath) {
+  try {
+    main();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
+}

--- a/tests/agentPluginMetadata.test.ts
+++ b/tests/agentPluginMetadata.test.ts
@@ -24,12 +24,15 @@ const agent = readFileSync(
   join(pluginRoot, "com.github.copilot", "agents", "beads-project-manager.agent.md"),
   "utf8"
 );
+const pluginReadme = readFileSync(join(pluginRoot, "README.md"), "utf8");
+const pluginChangelog = readFileSync(join(pluginRoot, "CHANGELOG.md"), "utf8");
 const docs = readFileSync(join(repoRoot, "docs", "agent-plugin.md"), "utf8");
 
 describe("agent plugin metadata", () => {
   it("declares an Agent Plugins 1.0 manifest", () => {
     expect(plugin.$schema).toBe("https://agent-plugins.org/schemas/1.0.0/plugin.schema.json");
-    expect(plugin.name).toMatch(/^[a-z0-9][a-z0-9.-]*$/);
+    expect(plugin.name.length).toBeLessThanOrEqual(64);
+    expect(plugin.name).toMatch(/^(?!.*(?:--|\.\.))[a-z0-9](?:[a-z0-9.-]*[a-z0-9])?$/);
     expect(plugin.version).toMatch(/^\d+\.\d+\.\d+$/);
     expect(plugin.description.length).toBeGreaterThan(20);
     expect(plugin.extensions).toHaveProperty("com.github.copilot");
@@ -60,13 +63,27 @@ describe("agent plugin metadata", () => {
     );
     expect(skill).toContain("does not by itself\nmean that the task was accepted");
     expect(skill).toContain("Ask for approval before creating\nor rewiring tasks");
+    expect(skill).toContain("only when the host client exposes compatible agent or task tools");
   });
 
-  it("documents direct and marketplace installation without conflating the VSIX", () => {
+  it("documents supported marketplace installation without conflating cache or VSIX boundaries", () => {
+    expect(docs).toContain('"chat.plugins.enabled": true');
     expect(docs).toContain('"chat.plugins.marketplaces"');
     expect(docs).toContain("copilot plugin marketplace add ToppyMicroServices/beads-git-graph");
     expect(docs).toContain("ToppyMicroServices/beads-git-graph:agent-plugin");
+    expect(docs).not.toContain(
+      "copilot plugin install ToppyMicroServices/beads-git-graph:agent-plugin"
+    );
     expect(docs).toContain("It is separate from the Beads Git Graph VSIX");
+    expect(docs).toContain("full public repository into a separate marketplace source cache");
+    expect(docs).toContain("outside the active plugin payload");
     expect(docs).toContain("a separate review and\nsubmission process");
+  });
+
+  it("provides a safe first prompt and plugin-specific release history", () => {
+    expect(pluginReadme).toContain("## Start safely");
+    expect(pluginReadme).toContain("Do not mutate Beads or start agents.");
+    expect(pluginReadme).toContain("compatible agent or task tools from the host client");
+    expect(pluginChangelog).toContain(`## [${plugin.version}] - 2026-08-30`);
   });
 });

--- a/tests/agentPluginRelease.test.ts
+++ b/tests/agentPluginRelease.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  changesPluginRelease,
+  checkTagVersion,
+  checkVersionBump,
+  compareSemver,
+  parseArguments,
+  PLUGIN_NAME_PATTERN,
+  validatePluginMetadata
+} from "../scripts/check-agent-plugin-release.mjs";
+
+const validPlugin = {
+  $schema: "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+  name: "beads-agent-project-manager",
+  version: "0.1.1",
+  description: "Coordinate Beads tasks safely.",
+  extensions: { "com.github.copilot": {} }
+};
+
+const validMarketplace = {
+  metadata: { version: "0.1.1" },
+  plugins: [
+    {
+      name: "beads-agent-project-manager",
+      version: "0.1.1",
+      description: "Coordinate Beads tasks safely.",
+      source: "./agent-plugin"
+    }
+  ]
+};
+
+describe("Agent Plugin release checks", () => {
+  it("uses the canonical Agent Plugins 1.0 name pattern", () => {
+    expect(PLUGIN_NAME_PATTERN.test("beads-agent-project-manager")).toBe(true);
+    expect(PLUGIN_NAME_PATTERN.test("beads.project-manager")).toBe(true);
+    expect(PLUGIN_NAME_PATTERN.test("beads--manager")).toBe(false);
+    expect(PLUGIN_NAME_PATTERN.test("beads..manager")).toBe(false);
+    expect(PLUGIN_NAME_PATTERN.test("beads-manager-")).toBe(false);
+  });
+
+  it("rejects unknown, duplicate, and incomplete CLI options", () => {
+    expect(parseArguments([])).toEqual({ base: null, tag: null });
+    expect(parseArguments(["--base", "origin/main"])).toEqual({ base: "origin/main", tag: null });
+    expect(() => parseArguments(["--unknown", "value"])).toThrow("Usage");
+    expect(() => parseArguments(["--base"])).toThrow("Usage");
+    expect(() => parseArguments(["--base", "main", "--tag", "agent-plugin-v0.1.1"])).toThrow(
+      "Usage"
+    );
+  });
+
+  it("compares semantic versions numerically", () => {
+    expect(compareSemver("0.1.1", "0.1.0")).toBe(1);
+    expect(compareSemver("0.10.0", "0.9.9")).toBe(1);
+    expect(compareSemver("1.0.0", "1.0.0")).toBe(0);
+    expect(compareSemver("1.0.0", "2.0.0")).toBe(-1);
+  });
+
+  it("requires a version increase when the plugin release changes", () => {
+    expect(changesPluginRelease(["docs/agent-plugin.md"])).toBe(false);
+    expect(changesPluginRelease(["agent-plugin/README.md"])).toBe(true);
+    expect(changesPluginRelease([".github/plugin/marketplace.json"])).toBe(true);
+    expect(() => checkVersionBump("0.1.0", "0.1.0", ["agent-plugin/README.md"])).toThrow(
+      "without a version increase"
+    );
+    expect(() => checkVersionBump("0.1.1", "0.1.0", ["agent-plugin/README.md"])).not.toThrow();
+  });
+
+  it("matches Agent Plugin tags to manifest versions", () => {
+    expect(() => checkTagVersion("agent-plugin-v0.1.1", "0.1.1")).not.toThrow();
+    expect(() => checkTagVersion("agent-plugin-v0.1.0", "0.1.1")).toThrow(
+      "does not match plugin version"
+    );
+    expect(() => checkTagVersion("v0.1.1", "0.1.1")).toThrow("Invalid Agent Plugin tag");
+  });
+
+  it("keeps the marketplace entry aligned with the plugin manifest", () => {
+    expect(() => validatePluginMetadata(validPlugin, validMarketplace)).not.toThrow();
+    for (const invalidExtension of [null, []]) {
+      expect(() =>
+        validatePluginMetadata(
+          { ...validPlugin, extensions: { "com.github.copilot": invalidExtension } },
+          validMarketplace
+        )
+      ).toThrow("must be a JSON object");
+    }
+    expect(() =>
+      validatePluginMetadata({ ...validPlugin, unsupported: true }, validMarketplace)
+    ).toThrow("unsupported field");
+    expect(() =>
+      validatePluginMetadata({ ...validPlugin, author: "invalid" }, validMarketplace)
+    ).toThrow("author must be a JSON object");
+    expect(() =>
+      validatePluginMetadata({ ...validPlugin, keywords: ["beads", 1] }, validMarketplace)
+    ).toThrow("keywords must be an array of strings");
+    expect(() =>
+      validatePluginMetadata(validPlugin, {
+        ...validMarketplace,
+        plugins: [{ ...validMarketplace.plugins[0], source: "../agent-plugin" }]
+      })
+    ).toThrow("marketplace source must remain ./agent-plugin");
+  });
+});

--- a/tests/releaseMetadata.test.ts
+++ b/tests/releaseMetadata.test.ts
@@ -9,6 +9,11 @@ const packageJson = JSON.parse(readFileSync(join(repoRoot, "package.json"), "utf
 };
 const readme = readFileSync(join(repoRoot, "README.md"), "utf8");
 const publishWorkflow = readFileSync(join(repoRoot, ".github", "workflows", "publish.yml"), "utf8");
+const agentPluginReleaseWorkflow = readFileSync(
+  join(repoRoot, ".github", "workflows", "agent-plugin-release.yml"),
+  "utf8"
+);
+const ciWorkflow = readFileSync(join(repoRoot, ".github", "workflows", "ci.yaml"), "utf8");
 
 describe("release metadata", () => {
   it("keeps the README version badge in sync with package.json", () => {
@@ -22,8 +27,23 @@ describe("release metadata", () => {
     expect(publishWorkflow).toContain(
       "!startsWith(github.event.release.tag_name, 'agent-plugin-')"
     );
+    expect(publishWorkflow).toContain("!startsWith(github.ref_name, 'daily-')");
+    expect(publishWorkflow).toContain("!startsWith(github.ref_name, 'agent-plugin-')");
     expect(publishWorkflow).toContain('pnpm exec ovsx -p "$OPEN_VSX_TOKEN" publish -i');
     expect(publishWorkflow).toContain("pnpm exec vsce publish --packagePath");
     expect(publishWorkflow).not.toContain("pnpm dlx");
+  });
+
+  it("checks Agent Plugin version bumps and release tags", () => {
+    expect(ciWorkflow).toContain(
+      // eslint-disable-next-line no-template-curly-in-string
+      'node ./scripts/check-agent-plugin-release.mjs --base "origin/${{ github.base_ref }}"'
+    );
+    expect(agentPluginReleaseWorkflow).toContain("agent-plugin-v*");
+    expect(agentPluginReleaseWorkflow).toContain("fetch-depth: 0");
+    expect(agentPluginReleaseWorkflow).toContain("github.event.repository.default_branch");
+    expect(agentPluginReleaseWorkflow).toContain(
+      'node ./scripts/check-agent-plugin-release.mjs --tag "$AGENT_PLUGIN_TAG"'
+    );
   });
 });


### PR DESCRIPTION
## Summary

- Correct Agent Plugin installation and cache-boundary documentation.
- Harden plugin versioning and release validation for v0.1.1.

## Changes

- Add the required VS Code plugin enablement setting and a safe first-use prompt.
- Distinguish the active plugin payload from the full-repository marketplace source cache.
- Clarify that parallel-agent startup depends on host tools and direct CLI installs emit a deprecation warning at runtime.
- Add plugin-specific release history and bump manifest and marketplace metadata to 0.1.1.
- Require plugin version bumps on PRs and validate explicit Agent Plugin tags with a trusted checker.
- Prevent manual VSIX publishing from daily and Agent Plugin tags.

## Testing

- pnpm run format
- pnpm run lint
- pnpm run typecheck
- pnpm test: 442 passed, 1 skipped
- pnpm run audit: no known vulnerabilities
- pnpm run package
- Isolated Copilot CLI 1.0.82 marketplace install smoke for v0.1.1
- Revalidated agent-plugin-v0.1.0 with the new tag checker
- actionlint on the changed workflows

## Notes

- The active installed plugin is sourced only from agent-plugin. Self-hosted marketplace clients can still cache the public repository outside that active payload.